### PR TITLE
fix: add mock container manager implementation

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -604,12 +604,12 @@ func (c *Container) BuildingContainer(opts types.ContainerConfig) error {
 	return err
 }
 
-func (c *Container) BuildIntermidiateContainer(image string, dockerFile []byte, platform ...string) error {
-	if len(platform) == 0 {
-		platform = []string{GetBuild().Platform.Container.String()}
+func (c *Container) BuildIntermidiateContainer(image string, dockerFile []byte, platforms ...string) error {
+	if len(platforms) == 0 {
+		platforms = []string{GetBuild().Platform.Container.String()}
 	}
 
-	exists, err := c.ImageExists(image, platform...)
+	exists, err := c.ImageExists(image, platforms...)
 	if err != nil {
 		slog.Error("Failed to check if image exists", "error", err)
 		os.Exit(1)
@@ -619,17 +619,17 @@ func (c *Container) BuildIntermidiateContainer(image string, dockerFile []byte, 
 		return nil
 	}
 
-	err = c.PullByPlatform(platform[0], image)
+	err = c.PullByPlatform(platforms[0], image)
 	if err != nil {
-		slog.Warn("Failed to pull intermediate image. Has to build now then", "error", err, "image", image, "platform", platform[0])
+		slog.Warn("Failed to pull intermediate image. Has to build now then", "error", err, "image", image, "platform", platforms[0])
 	}
 
 	if err == nil {
-		slog.Info("Image successfully pulled", "image", image, "platform", platform[0])
+		slog.Info("Image successfully pulled", "image", image, "platforms", platforms)
 		return nil
 	}
 
-	if len(platform) == 1 {
+	if len(platforms) == 1 {
 		slog.Info("Start building intermediate container image", "image", image)
 		err = c.BuildImage(dockerFile, image)
 		if err != nil {
@@ -663,7 +663,7 @@ func (c *Container) BuildIntermidiateContainer(image string, dockerFile []byte, 
 		// err = c.Container.BuildImage(dockerFile, image)
 		// TODO get list of platforms
 		// Multi-platform builds are already pushed otherwise there are not usable by podman or docker
-		_, err = c.BuildImageByPlatforms(dockerFile, image, []string{"linux/arm64", "linux/amd64"})
+		_, err = c.BuildImageByPlatforms(dockerFile, image, platforms)
 		if err != nil {
 			slog.Error("Failed to build image", "error", err)
 			os.Exit(1)

--- a/pkg/cri/critest/critest.go
+++ b/pkg/cri/critest/critest.go
@@ -1,0 +1,250 @@
+package critest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+
+	"github.com/containifyci/engine-ci/pkg/cri/types"
+)
+
+// Error types for better testing simulation
+var (
+	ErrContainerNotFound = errors.New("container not found")
+	ErrImageNotFound     = errors.New("image not found")
+)
+
+// MockContainerManager is a mock implementation of the ContainerManager interface.
+type MockContainerManager struct {
+	Containers           map[string]*MockContainerLifecycle
+	ContainerLogsEntries map[string][]string
+	Images               map[string]*MockImageLifecycle
+	ImagesLogEntries     []string
+	Errors               map[string]error
+}
+
+type MockContainerLifecycle struct {
+	ID     string
+	Opts   *types.ContainerConfig
+	State  string
+	Volume *MockContainerVolume
+}
+
+type MockContainerVolume struct {
+	Content string
+	SrcPath string
+	DstPath string
+}
+
+type MockImageLifecycle struct {
+	ID        string
+	Opts      *types.ImageInfo
+	BuildInfo MockImageBuildInfo
+}
+
+type MockImageBuildInfo struct {
+	ID         string
+	Name       string
+	Dockerfile []byte
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// randString generates a random string of length n.
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func NewMockContainerManager() (*MockContainerManager, error) {
+	return &MockContainerManager{
+		Containers:           make(map[string]*MockContainerLifecycle),
+		ContainerLogsEntries: make(map[string][]string),
+		Images:               make(map[string]*MockImageLifecycle),
+		ImagesLogEntries:     []string{},
+		Errors:               make(map[string]error),
+	}, nil
+}
+
+func (m *MockContainerManager) Reset() {
+	m.Containers = make(map[string]*MockContainerLifecycle)
+	m.ContainerLogsEntries = make(map[string][]string)
+	m.Images = make(map[string]*MockImageLifecycle)
+	m.ImagesLogEntries = []string{}
+	m.Errors = make(map[string]error)
+}
+
+func (m *MockContainerManager) GetContainerByImage(image string) *MockContainerLifecycle {
+	for _, con := range m.Containers {
+		if con.Opts.Image == image {
+			return con
+		}
+	}
+	return nil
+}
+
+func (m *MockContainerManager) GetContainer(id string) *MockContainerLifecycle {
+	return m.Containers[id]
+}
+
+func (m *MockContainerManager) GetImage(id string) *MockImageLifecycle {
+	return m.Images[id]
+}
+
+func (m *MockContainerManager) CreateContainer(ctx context.Context, opts *types.ContainerConfig, authBase64 string) (string, error) {
+	id := randString(6)
+	m.Containers[id] = &MockContainerLifecycle{ID: id, Opts: opts, State: "created"}
+	return id, nil
+}
+
+func (m *MockContainerManager) StartContainer(ctx context.Context, id string) error {
+	if _, exists := m.Containers[id]; !exists {
+		return ErrContainerNotFound
+	}
+	m.Containers[id].State = "started"
+	m.ContainerLogsEntries[m.Containers[id].Opts.Image] = []string{"container starting", "container running"}
+	return nil
+}
+
+func (m *MockContainerManager) StopContainer(ctx context.Context, id string, signal string) error {
+	if _, exists := m.Containers[id]; !exists {
+		return ErrContainerNotFound
+	}
+	m.ContainerLogsEntries[m.Containers[id].Opts.Image] = append(m.ContainerLogsEntries[m.Containers[id].Opts.Image], "container stopped")
+	m.Containers[id].State = "stopped"
+	return nil
+}
+
+func (m *MockContainerManager) CommitContainer(ctx context.Context, containerID string, opts types.CommitOptions) (string, error) {
+	imageID := containerID
+	return imageID, nil
+}
+
+func (m *MockContainerManager) RemoveContainer(ctx context.Context, containerID string) error {
+	delete(m.Containers, containerID)
+	return nil
+}
+
+func (m *MockContainerManager) ContainerList(ctx context.Context, all bool) ([]*types.Container, error) {
+	var containerList []*types.Container
+	for id, con := range m.Containers {
+		containerList = append(containerList, &types.Container{ID: id, Image: con.Opts.Image, ImageID: id, Names: []string{con.Opts.Name}})
+	}
+	return containerList, nil
+}
+
+func (m *MockContainerManager) ContainerLogs(ctx context.Context, id string, showStdout bool, showStderr bool, follow bool) (io.ReadCloser, error) {
+	con, exists := m.Containers[id]
+	if !exists {
+		return nil, ErrContainerNotFound
+	}
+
+	if logs, exists := m.ContainerLogsEntries[con.Opts.Image]; exists {
+		return io.NopCloser(strings.NewReader(strings.Join(logs, "\n"))), nil
+	}
+	return nil, ErrContainerNotFound
+}
+
+func (m *MockContainerManager) CopyContentToContainer(ctx context.Context, id, content, dest string) error {
+	m.Containers[id].Volume = &MockContainerVolume{Content: content, DstPath: dest}
+	return nil
+}
+
+func (m *MockContainerManager) CopyDirectorToContainer(ctx context.Context, id, srcPath, dstPath string) error {
+	m.Containers[id].Volume = &MockContainerVolume{SrcPath: srcPath, DstPath: dstPath}
+	return nil
+}
+
+func (m *MockContainerManager) CopyToContainer(ctx context.Context, id, srcPath, dstPath string) error {
+	m.Containers[id].Volume = &MockContainerVolume{SrcPath: srcPath, DstPath: dstPath}
+	return nil
+}
+
+func (m *MockContainerManager) CopyFileFromContainer(ctx context.Context, id string, srcPath string) (string, error) {
+	return m.Containers[id].Volume.Content, nil
+}
+
+func (m *MockContainerManager) ExecContainer(ctx context.Context, id string, cmd []string, attachStdOut bool) (io.Reader, error) {
+	return strings.NewReader("mock_exec_output"), nil
+}
+
+func (m *MockContainerManager) InspectContainer(ctx context.Context, id string) (*types.ContainerConfig, error) {
+	if container, exists := m.Containers[id]; exists {
+		return container.Opts, nil
+	}
+	return nil, ErrContainerNotFound
+}
+
+func (m *MockContainerManager) WaitContainer(ctx context.Context, id string, waitCondition string) (*int64, error) {
+	exitCode := int64(0)
+	return &exitCode, nil
+}
+
+func (m *MockContainerManager) BuildImage(ctx context.Context, dockerfile []byte, imageName string, platform string) (io.ReadCloser, error) {
+	id := randString(6)
+	platformSpec := types.ParsePlatform(platform)
+	m.Images[imageName] = &MockImageLifecycle{ID: id, Opts: &types.ImageInfo{ID: id, Platform: platformSpec}, BuildInfo: MockImageBuildInfo{ID: id, Name: imageName, Dockerfile: dockerfile}}
+	return io.NopCloser(strings.NewReader("mock_build_output")), nil
+}
+
+func (m *MockContainerManager) BuildMultiArchImage(ctx context.Context, dockerfile []byte, imageName string, platforms []string, authBase64 string) (io.ReadCloser, []string, error) {
+	for _, platform := range platforms {
+		m.BuildImage(ctx, dockerfile, imageName + "-" + platform, platform)
+	}
+
+	return io.NopCloser(strings.NewReader("mock_multiarch_build_output")), platforms, nil
+}
+
+func (m *MockContainerManager) ListImage(ctx context.Context, image string) ([]string, error) {
+	images := []string{}
+	for _, img := range m.Images {
+		if img.BuildInfo.Name == image {
+			images = append(images, img.BuildInfo.Name)
+		}
+	}
+	return images, nil
+}
+
+func (m *MockContainerManager) PullImage(ctx context.Context, image string, authBase64 string, platform string) (io.ReadCloser, error) {
+	if _, exists := m.Errors[image]; exists {
+		return nil, m.Errors[image]
+	}
+
+	id := randString(6)
+	m.Images[image] = &MockImageLifecycle{ID: id, Opts: &types.ImageInfo{ID: id}}
+	m.ImagesLogEntries = append(m.ImagesLogEntries, fmt.Sprintf("%s pulled", image))
+	return io.NopCloser(strings.NewReader(fmt.Sprintf("%s pulled", image))), nil
+}
+
+func (m *MockContainerManager) TagImage(ctx context.Context, source, target string) error {
+	if img, exists := m.Images[source]; exists {
+		m.Images[target] = img
+	}
+	return nil
+}
+
+func (m *MockContainerManager) PushImage(ctx context.Context, target string, authBase64 string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("mock_push_output")), nil
+}
+
+func (m *MockContainerManager) RemoveImage(ctx context.Context, target string) error {
+	delete(m.Images, target)
+	return nil
+}
+
+func (m *MockContainerManager) InspectImage(ctx context.Context, image string) (*types.ImageInfo, error) {
+	if img, exists := m.Images[image]; exists {
+		return img.Opts, nil
+	}
+	return nil, ErrImageNotFound
+}
+
+func (m *MockContainerManager) Name() string {
+	return "MockContainerManager"
+}

--- a/pkg/cri/critest/critest_test.go
+++ b/pkg/cri/critest/critest_test.go
@@ -1,0 +1,106 @@
+package critest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/containifyci/engine-ci/pkg/cri/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockContainer_ContainerLifecycle(t *testing.T) {
+	ctx := context.TODO()
+	// Create a new MockContainerManager
+	m, _ := NewMockContainerManager()
+
+	// Create a new container configuration
+	containerConfig := &types.ContainerConfig{
+		Name: "test-container",
+		Image: "test-image",
+	}
+
+	// Create a new container
+	containerID, err := m.CreateContainer(ctx, containerConfig, "")
+	assert.NoError(t, err)
+	assert.Equal(t, "created", m.GetContainer(containerID).State)
+
+	cons, err := m.ContainerList(ctx, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, cons)
+	assert.Len(t, cons, 1)
+	assert.Equal(t, containerID, cons[0].ID)
+
+	// Start the container
+	err = m.StartContainer(ctx, containerID)
+	assert.NoError(t, err)
+	assert.Equal(t, "started", m.GetContainer(containerID).State)
+
+	// Stop the container
+	err = m.StopContainer(ctx, containerID, "")
+	assert.NoError(t, err)
+	assert.Equal(t, "stopped", m.GetContainer(containerID).State)
+
+	// Commit the container
+	_, err = m.CommitContainer(ctx, containerID, types.CommitOptions{})
+	assert.NoError(t, err)
+
+	cnt, err := m.ContainerLogs(ctx, containerID, true, true, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, cnt)
+	var b bytes.Buffer
+	io.Copy(&b, cnt)
+	assert.NotEmpty(t, b.String())
+	assert.Equal(t, "container starting\ncontainer running\ncontainer stopped", b.String())
+
+	// Remove the container
+	err = m.RemoveContainer(ctx, containerID)
+	assert.NoError(t, err)
+
+	cons, err = m.ContainerList(ctx, true)
+	assert.NoError(t, err)
+	assert.Nil(t, cons)
+	assert.Len(t, cons, 0)
+}
+
+func TestMockContainer_ImageLifecycle(t *testing.T) {
+	ctx := context.TODO()
+	// Create a new MockContainerManager
+	m, _ := NewMockContainerManager()
+
+	cnt, err := m.BuildImage(ctx, []byte("TestDockerFiles"),"test-image", "")
+	assert.NoError(t, err)
+	assert.NotNil(t, cnt)
+	var b bytes.Buffer
+	io.Copy(&b, cnt)
+	assert.NotEmpty(t, b.String())
+	assert.Equal(t, "mock_build_output", b.String())
+
+	imgs, err := m.ListImage(ctx, "test-image")
+	assert.NoError(t, err)
+	assert.NotNil(t, imgs)
+	assert.Len(t, imgs, 1)
+	assert.Equal(t, "test-image", imgs[0])
+
+	cnt, err = m.PullImage(ctx, "test-pull-image", "", "")
+	assert.NoError(t, err)
+	assert.NotNil(t, cnt)
+	b.Reset()
+	io.Copy(&b, cnt)
+	assert.NotEmpty(t, b.String())
+	assert.Equal(t, "test-pull-image pulled", b.String())
+	assert.Len(t, m.Images, 2)
+
+	imgInfo, err := m.InspectImage(ctx, "test-image")
+	assert.NoError(t, err)
+	assert.NotNil(t, imgInfo)
+
+	err = m.RemoveImage(ctx, "test-pull-image")
+	assert.NoError(t, err)
+	assert.Len(t, m.Images, 1)
+
+	err = m.TagImage(ctx, "test-image", "test-tag-image")
+	assert.NoError(t, err)
+	assert.Len(t, m.Images, 2)
+}

--- a/pkg/cri/manager.go
+++ b/pkg/cri/manager.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"sync"
 
+	"github.com/containifyci/engine-ci/pkg/cri/critest"
 	"github.com/containifyci/engine-ci/pkg/cri/docker"
 	"github.com/containifyci/engine-ci/pkg/cri/podman"
 	"github.com/containifyci/engine-ci/pkg/cri/types"
@@ -65,12 +66,14 @@ func getRuntime() (ContainerManager, error) {
 	case utils.Podman:
 		fmt.Println("Using Podman")
 		return podman.NewPodmanManager()
+	case utils.Test:
+		fmt.Println("Using Test")
+		return critest.NewMockContainerManager()
 	default:
 		slog.Error("unknown container runtime stop")
 		os.Exit(1)
 	}
 	return nil, fmt.Errorf("unknown container runtime stop")
-
 }
 
 func DetectContainerRuntime() utils.RuntimeType {
@@ -83,6 +86,9 @@ func DetectContainerRuntime() utils.RuntimeType {
 		case "podman":
 			fmt.Println("Detect Podman")
 			return utils.Podman
+		case "test":
+			fmt.Println("Detect Test")
+			return utils.Test
 		default:
 			slog.Error("unknown container runtime", "runtime", runtime)
 			os.Exit(1)

--- a/pkg/cri/utils/runtime.go
+++ b/pkg/cri/utils/runtime.go
@@ -3,6 +3,7 @@ package utils
 const (
 	Docker  RuntimeType = "docker"
 	Podman  RuntimeType = "podman"
+	Test    RuntimeType = "test"
 	Unknown RuntimeType = "unknown"
 )
 


### PR DESCRIPTION
This mock container manager is useful to write unit test for containifyci pipeline implementation. For an example look at [maven_test.go](https://github.com/containifyci/java/tree/main/pkg/maven_test.go)