### PR TITLE
chore: environment cmd only use stdout

### DIFF
--- a/pkg/utils/environment.go
+++ b/pkg/utils/environment.go
@@ -49,7 +49,7 @@ func GetEnv(key string, envType string) string {
 }
 
 func RunCommand(cmd string) (*string, error) {
-	out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
+	out, err := exec.Command("sh", "-c", cmd).Output()
 	if err != nil {
 		slog.Error("Error running command", "error", err, "command", cmd)
 		return nil, err

--- a/pkg/utils/environment_test.go
+++ b/pkg/utils/environment_test.go
@@ -47,6 +47,7 @@ func TestGetEnv(t *testing.T) {
 	t.Setenv("key", "value")
 	t.Setenv("key_env", "env:key")
 	t.Setenv("key_cmd", "cmd:echo value")
+	t.Setenv("key_cmd_default", "cmd:cat file || echo value")
 	tests := []struct {
 		key  string
 		want string
@@ -61,6 +62,10 @@ func TestGetEnv(t *testing.T) {
 		},
 		{
 			key:  "key_cmd",
+			want: "value",
+		},
+		{
+			key:  "key_cmd_default",
 			want: "value",
 		},
 	}


### PR DESCRIPTION
This way it supports shell logic operator like
`cat non_file || echo default_value`.