### PR TITLE
fix(docker): expose ports were not accessible

### DIFF
--- a/pkg/cri/docker/docker.go
+++ b/pkg/cri/docker/docker.go
@@ -85,7 +85,7 @@ func (d *DockerManager) CreateContainer(ctx context.Context, opts *types.Contain
 			HostPort: p.Host.Port,
 		}
 		// binding, set := p.ToPortBinding()
-		portMap[nat.Port(p.Container.IP)] = []nat.PortBinding{portBinding}
+		portMap[nat.Port(p.Container.String())] = []nat.PortBinding{portBinding}
 		portSet[nat.Port(p.Container.Port)] = struct{}{}
 	}
 	config.ExposedPorts = portSet

--- a/pkg/cri/podman/podman.go
+++ b/pkg/cri/podman/podman.go
@@ -885,20 +885,20 @@ func DecodeRegistryAuth(authBase64 string) (*registry.AuthConfig, error) {
 		return nil, err
 	}
 
-	var authCfg *registry.AuthConfig
+	var authCfg registry.AuthConfig
 
 	if len(base64Decoded) <= 0 {
-		return authCfg, nil
+		return &authCfg, nil
 	}
 
-	err = json.Unmarshal(base64Decoded, authCfg)
+	err = json.Unmarshal(base64Decoded, &authCfg)
 	if err != nil {
 		//TODO mask possible password leak in error message
 		slog.Error("Failed to unmarshal auth config", "error", err, "auth", string(base64Decoded))
 		return nil, err
 	}
 
-	return authCfg, nil
+	return &authCfg, nil
 }
 
 // PushImage pushes an image

--- a/pkg/cri/types/container.go
+++ b/pkg/cri/types/container.go
@@ -14,6 +14,13 @@ type PortBinding struct {
 	Port string
 }
 
+func (p PortBinding) String() string {
+	if p.IP != "" {
+		return p.IP + ":" + p.Port
+	}
+	return p.Port
+}
+
 type Binding struct {
 	Host      PortBinding
 	Container PortBinding


### PR DESCRIPTION
In the latest docker version (27.2.0) the ports were not accessible from the host anymore. That was because they were not configured properly in with engine-ci. This commit fixes that issue.