### PR TITLE
chore: fix of too many request error for trivy

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -18,6 +18,10 @@ func registryAuth() map[string]*protos2.ContainerRegistry {
 			Username: "env:DOCKER_USER",
 			Password: "env:DOCKER_TOKEN",
 		},
+		"ghcr.io": {
+			Username: "USERNAME",
+			Password: "env:GHCR_TOKEN",
+		},
 	}
 }
 

--- a/pkg/trivy/trivy.go
+++ b/pkg/trivy/trivy.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	IMAGE = "ghcr.io/aquasecurity/trivy:canary"
+	IMAGE = "public.ecr.aws/aquasecurity/trivy:canary"
 )
 
 type TrivyContainer struct {
@@ -113,6 +113,8 @@ func (c *TrivyContainer) Scan() error {
 		"TRIVY_CACHE_DIR=/root/.cache/trivy",
 		"TRIVY_INSECURE=true",
 		"TRIVY_NON_SSL=true",
+		"TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db",
+		"TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db",
 	}
 
 	ssh, err := network.SSHForward()


### PR DESCRIPTION
The trivy ghcr.io packages reached rate limit quite often now. This PR is to fix the issue by using the aws offical trivy artifacts.