### PR TITLE
fix(golang): fix copy to push image

### DIFF
--- a/pkg/golang/alpine/golang.go
+++ b/pkg/golang/alpine/golang.go
@@ -373,7 +373,7 @@ func (c *GoContainer) Prod() error {
 
 	slog.Info("Container info", "name", containerInfo.Name, "image", containerInfo.Image, "arch", containerInfo.Platform.Container.Architecture, "os", containerInfo.Platform.Container.OS, "varian", containerInfo.Platform.Container.Variant)
 
-	err = c.Container.CopyFileTo(fmt.Sprintf("./%s-%s-%s", c.App, containerInfo.Platform.Container.OS, containerInfo.Platform.Container.Architecture), fmt.Sprintf("/app/%s", c.App))
+	err = c.Container.CopyFileTo(fmt.Sprintf("%s/%s-%s-%s", c.Folder, c.App, containerInfo.Platform.Container.OS, containerInfo.Platform.Container.Architecture), fmt.Sprintf("/app/%s", c.App))
 	if err != nil {
 		slog.Error("Failed to copy file to container", "error", err)
 		os.Exit(1)

--- a/pkg/golang/debian/golang.go
+++ b/pkg/golang/debian/golang.go
@@ -369,7 +369,7 @@ func (c *GoContainer) Prod() error {
 
 	slog.Info("Container info", "name", containerInfo.Name, "image", containerInfo.Image, "arch", containerInfo.Platform.Container.Architecture, "os", containerInfo.Platform.Container.OS, "varian", containerInfo.Platform.Container.Variant)
 
-	err = c.Container.CopyFileTo(fmt.Sprintf("./%s-%s-%s", c.App, containerInfo.Platform.Container.OS, containerInfo.Platform.Container.Architecture), fmt.Sprintf("/app/%s", c.App))
+	err = c.Container.CopyFileTo(fmt.Sprintf("%s/%s-%s-%s", c.Folder, c.App, containerInfo.Platform.Container.OS, containerInfo.Platform.Container.Architecture), fmt.Sprintf("/app/%s", c.App))
 	if err != nil {
 		slog.Error("Failed to copy file to container", "error", err)
 		os.Exit(1)

--- a/pkg/golang/debiancgo/golang.go
+++ b/pkg/golang/debiancgo/golang.go
@@ -373,7 +373,7 @@ func (c *GoContainer) Prod() error {
 
 	slog.Info("Container info", "name", containerInfo.Name, "image", containerInfo.Image, "arch", containerInfo.Platform.Container.Architecture, "os", containerInfo.Platform.Container.OS, "varian", containerInfo.Platform.Container.Variant)
 
-	err = c.Container.CopyFileTo(fmt.Sprintf("./%s-%s-%s", c.App, containerInfo.Platform.Container.OS, containerInfo.Platform.Container.Architecture), fmt.Sprintf("/app/%s", c.App))
+	err = c.Container.CopyFileTo(fmt.Sprintf("%s/%s-%s-%s", c.Folder, c.App, containerInfo.Platform.Container.OS, containerInfo.Platform.Container.Architecture), fmt.Sprintf("/app/%s", c.App))
 	if err != nil {
 		slog.Error("Failed to copy file to container", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
The compiled binary was not being found because the copy command was not copying the binary from the defined Folder.