### PR TITLE
refactor(build): rename files and add library builds

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -33,7 +33,7 @@ func main() {
 	protos2.Image = ""
 
 	client := build.NewGoServiceBuild("engine-ci-client")
-	client.File = "goflip.go"
+	client.File = "client.go"
 	client.Folder = "client"
 	client.Image = ""
 

--- a/client/client.go
+++ b/client/client.go
@@ -8,11 +8,7 @@ import (
 var opts protos2.BuildArgs
 
 func init() {
-	// os.Chdir("..")
 	opts = protos2.BuildArgs{}
-	// opts.Custom = map[string][]string{
-	// 	"tags": {"containers_image_openpgp"},
-	// }
 	opts.Verbose = true
 	opts.File = "containifyci.go"
 	opts.Application = "containifyci-cli"

--- a/client/pkg/build/build.go
+++ b/client/pkg/build/build.go
@@ -52,7 +52,6 @@ func NewServiceBuild(appName string, buildType protos2.BuildType) *BuildArgs {
 		Image:       appName,
 		ImageTag:    commitSha,
 		BuildType:   buildType,
-		// Platform:       "linux/amd64",
 		SourcePackages: packages,
 		SourceFiles:    files,
 	}
@@ -62,12 +61,30 @@ func NewGoServiceBuild(appName string) *BuildArgs {
 	return NewServiceBuild(appName, protos2.BuildType_GoLang)
 }
 
+func NewGoLibraryBuild(appName string) *BuildArgs {
+	lib := NewGoServiceBuild(appName)
+	lib.Image = ""
+	return lib
+}
+
 func NewMavenServiceBuild(appName string) *BuildArgs {
 	build := NewServiceBuild(appName, protos2.BuildType_Maven)
 	build.Folder = "target/quarkus-app"
 	return build
 }
 
+func NewMavenLibraryBuild(appName string) *BuildArgs {
+	lib := NewMavenServiceBuild(appName)
+	lib.Image = ""
+	return lib
+}
+
 func NewPythonServiceBuild(appName string) *BuildArgs {
 	return NewServiceBuild(appName, protos2.BuildType_Python)
+}
+
+func NewPythonLibraryBuild(appName string) *BuildArgs {
+	lib := NewPythonServiceBuild(appName)
+	lib.Image = ""
+	return lib
 }


### PR DESCRIPTION
Rename `goflip.go` to `client.go` for clarity. Remove unused code and comments for cleaner code.

Add new functions `NewGoLibraryBuild`, `NewMavenLibraryBuild`, and `NewPythonLibraryBuild` for additional library build capabilities, which return build arguments without building container images.

- Rename `goflip.go` to `client.go`
- Add `NewGoLibraryBuild` function
- Add `NewMavenLibraryBuild` function
- Add `NewPythonLibraryBuild` function