### PR TITLE
refactor(container): support parallel build process

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -37,6 +37,8 @@ func main() {
 	client.Folder = "client"
 	client.Image = ""
 
+	// build.Serve(protos2, client)
+
 	opts1 := build.NewGoServiceBuild("engine-ci")
 	opts1.File = "main.go"
 	opts1.Properties = map[string]*build.ListValue{
@@ -45,7 +47,7 @@ func main() {
 
 	opts1.Registries = registryAuth()
 
-	opts2 := build.NewGoServiceBuild("engine-ci")
+	opts2 := build.NewGoServiceBuild("engine-ci-debian")
 	opts2.File = "main.go"
 	opts2.Properties = map[string]*build.ListValue{
 		"tags":       build.NewList("containers_image_openpgp"),
@@ -53,5 +55,6 @@ func main() {
 		"goreleaser": build.NewList("false"),
 	}
 	opts2.Registries = registryAuth()
+	// build.Serve(opts1, opts2)
 	build.Serve(protos2, client, opts1, opts2)
 }

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/cri/utils"
 	"github.com/spf13/cobra"
 )
@@ -57,7 +56,7 @@ func init() {
 
 func SaveCache() error {
 	args := GetBuild()
-	bs := Pre(args...)
+	_, bs := Pre(args[0])
 	images := bs.Images()
 	if len(images) == 0 {
 		return nil
@@ -97,7 +96,7 @@ docker save -o ~/image-cache/%s.tar %s
 
 func LoadCache() error {
 	args := GetBuild()
-	bs := Pre(args...)
+	arg, bs := Pre(args[0])
 
 	images := bs.Images()
 	if len(images) == 0 {
@@ -117,13 +116,13 @@ func LoadCache() error {
 			slog.Error("Error parsing image", "error", err)
 			os.Exit(1)
 		}
-		if container.GetBuild().Runtime == utils.Docker {
+		if arg.Runtime == utils.Docker {
 			cmd := fmt.Sprintf(`
 set -x
 docker load -i ~/image-cache/%s.tar
 `, info.Image)
 			go runCommand(&wg, errs, "sh", []string{"-c", cmd}...)
-		} else if container.GetBuild().Runtime == utils.Podman {
+		} else if arg.Runtime == utils.Podman {
 			cmd := fmt.Sprintf(`
 set -x
 podman load -i ~/image-cache/%s.tar

--- a/cmd/github_actions.go
+++ b/cmd/github_actions.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/cri"
 	"github.com/containifyci/engine-ci/pkg/cri/utils"
 	"github.com/spf13/cobra"
@@ -35,7 +34,8 @@ func RunGithubAction() error {
 
 	// Define the script content
 	var scriptContent string
-	switch cri.DetectContainerRuntime() {
+	runtime := cri.DetectContainerRuntime()
+	switch runtime {
 	case utils.Docker:
 		slog.Info("Docker runtime detected")
 		scriptContent = `#!/bin/bash
@@ -67,8 +67,8 @@ ls -lha  /run/user/1001/podman/podman.sock
 echo "CONTAINER_PRIVILGED=false" >> $GITHUB_ENV
 `
 	default:
-		slog.Error("Unknown runtime", "runtime", container.GetBuild().Runtime)
-		return fmt.Errorf("unknown runtime: %s", container.GetBuild().Runtime)
+		slog.Error("Unknown runtime", "runtime", runtime)
+		return fmt.Errorf("unknown runtime: %s", runtime)
 	}
 
 	// Write the script to a temporary file

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,9 +3,8 @@ package cmd
 import (
 	"fmt"
 	"log/slog"
-	"os"
+	"sync"
 
-	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/logger"
 
 	"github.com/spf13/cobra"
@@ -50,6 +49,8 @@ to quickly create a Cobra application.`,
 	},
 }
 
+var mu sync.Mutex
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
@@ -70,11 +71,12 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&RootArgs.Progress, "progress", "plain", "The progress logging format to use. Options are: progress, plain")
 }
 
-func All(opts *container.Build) error {
-	os.Args[1] = "build"
-	os.Args = append(os.Args, opts.AsFlags()...)
-	return Execute()
-}
+// func All(opts *container.Build) error {
+// 	os.Args[1] = "build"
+// 	os.Args = append(os.Args, opts.AsFlags()...)
+// 	slog.Info("Running build command", "args", opts.AsFlags())
+// 	return Execute()
+// }
 
 func SetVersionInfo(version, commit, date, repo string) string {
 	rootCmd.Version = fmt.Sprintf("%s (Built on %s from Git SHA %s of %s)", version, date, commit, repo)

--- a/internal/service/main.go
+++ b/internal/service/main.go
@@ -68,10 +68,12 @@ func createContainer(w http.ResponseWriter, r *http.Request) {
 	c := cmd.NewCommand(buildArgs)
 	c.AddTarget("all", func() error {
 		fmt.Println("Running build")
-		cmd.RunBuild(nil, nil)
+		// cmd.RunBuild(nil, nil)
 		return nil
 	})
-	c.Run("all", container.NewBuild(&buildArgs))
+	// addr := Start()
+
+	// c.Run("all", container.NewBuild(&buildArgs))
 
 	// switch buildType {
 	// case "golang":

--- a/pkg/container/build.go
+++ b/pkg/container/build.go
@@ -23,7 +23,7 @@ const (
 )
 
 // TODO: Find a better way then a package global var
-var _build *Build
+// var _build *Build
 
 type BuildType string
 
@@ -83,6 +83,10 @@ func (c Custom) UInt(key string) uint {
 	return 0
 }
 
+type Leader interface {
+	Leader(id string, fnc func() error)
+}
+
 // TODO: add target container platform
 type Build struct {
 	App      string `json:"app"`
@@ -107,7 +111,9 @@ type Build struct {
 	Verbose            bool
 	Registries         map[string]*protos2.ContainerRegistry
 
+	//internal variables
 	defaults bool
+	Leader   Leader
 }
 
 func (b *Build) CustomString(key string) string {
@@ -178,16 +184,16 @@ func NewPythonServiceBuild(appName string) Build {
 }
 
 func NewBuild(build *Build) *Build {
-	_build = build
-	if _build.Runtime == "" {
-		InitRuntime()
+	// _build = build
+	if build.Runtime == "" {
+		InitRuntime(build)
 	}
-	return _build
+	return build
 }
 
-func InitRuntime() *Build {
-	_build.Runtime = cri.DetectContainerRuntime()
-	return _build
+func InitRuntime(build *Build) *Build {
+	build.Runtime = cri.DetectContainerRuntime()
+	return build
 }
 
 func (b *Build) Defaults() *Build {

--- a/pkg/golang/debian/golang.go
+++ b/pkg/golang/debian/golang.go
@@ -40,24 +40,24 @@ type GoContainer struct {
 	*container.Container
 }
 
-func New() *GoContainer {
-	platforms := []*types.PlatformSpec{container.GetBuild().Platform.Container}
-	if !container.GetBuild().Platform.Same() {
-		slog.Info("Different platform detected", "host", container.GetBuild().Platform.Host, "container", container.GetBuild().Platform.Container)
+func New(build container.Build) *GoContainer {
+	platforms := []*types.PlatformSpec{build.Platform.Container}
+	if !build.Platform.Same() {
+		slog.Info("Different platform detected", "host", build.Platform.Host, "container", build.Platform.Container)
 		platforms = []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")}
 	}
 	return &GoContainer{
-		App:       container.GetBuild().App,
-		Container: container.New(container.BuildEnv),
-		Image:     container.GetBuild().Image,
-		ImageTag:  container.GetBuild().ImageTag,
+		App:       build.App,
+		Container: container.New(build),
+		Image:     build.Image,
+		ImageTag:  build.ImageTag,
 		// TODO: only build multiple platforms when buildenv and localenv are running on different platforms
 		// FIX: linux-arm64 go build is needed when building contains on MacOS M1/M2
 		// Platforms: []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")},
 		Platforms: platforms,
-		File:      container.GetBuild().File,
-		Folder:    container.GetBuild().Folder,
-		Tags:      container.GetBuild().Custom["tags"],
+		File:      build.File,
+		Folder:    build.Folder,
+		Tags:      build.Custom["tags"],
 	}
 }
 
@@ -103,10 +103,10 @@ func (g GoBuild) Name() string     { return g.name }
 func (g GoBuild) Images() []string { return g.images }
 func (g GoBuild) IsAsync() bool    { return g.async }
 
-func NewLinter() build.Build {
+func NewLinter(build container.Build) build.Build {
 	return GoBuild{
 		rf: func() error {
-			container := New()
+			container := New(build)
 			err := container.Container.Pull(LINT_IMAGE)
 			if err != nil {
 				slog.Error("Failed to pull image: %s", "error", err, "image", LINT_IMAGE)
@@ -138,7 +138,7 @@ ssh-keyscan github.com >> ~/.ssh/known_hosts
 git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
 GOOS=%s GOARCH=%s golangci-lint --out-format colored-line-number -v run %s --timeout=5m
 ls -lha /
-`, container.GetBuild().Platform.Container.OS, container.GetBuild().Platform.Container.Architecture, tags)
+`, c.GetBuild().Platform.Container.OS, c.GetBuild().Platform.Container.Architecture, tags)
 	err := c.Container.CopyContentTo(script, "/tmp/script.sh")
 	if err != nil {
 		slog.Error("Failed to copy script to container: %s", "error", err)
@@ -150,7 +150,7 @@ ls -lha /
 func (c *GoContainer) Lint() error {
 	imageTag := LintImage()
 
-	ssh, err := network.SSHForward()
+	ssh, err := network.SSHForward(*c.GetBuild())
 	if err != nil {
 		slog.Error("Failed to forward SSH", "error", err)
 		os.Exit(1)
@@ -221,7 +221,7 @@ func (c *GoContainer) Lint() error {
 	return err
 }
 
-func GoImage() string {
+func (c *GoContainer) GoImage() string {
 	dockerFile, err := f.ReadFile("Dockerfilego")
 	if err != nil {
 		slog.Error("Failed to read Dockerfile.go", "error", err)
@@ -229,17 +229,17 @@ func GoImage() string {
 	}
 	tag := container.ComputeChecksum(dockerFile)
 	image := fmt.Sprintf("golang-%s", DEFAULT_GO)
-	return utils.ImageURI(container.GetBuild().ContainifyRegistry, image, tag)
+	return utils.ImageURI(c.GetBuild().ContainifyRegistry, image, tag)
 }
 
 func (c *GoContainer) Images() []string {
 	imageTag := fmt.Sprintf("golang:%s", DEFAULT_GO)
 
-	return []string{imageTag, "alpine:latest", GoImage()}
+	return []string{imageTag, "alpine:latest", c.GoImage()}
 }
 
 func (c *GoContainer) BuildGoImage() error {
-	image := GoImage()
+	image := c.GoImage()
 
 	dockerFile, err := f.ReadFile("Dockerfilego")
 	if err != nil {
@@ -247,15 +247,15 @@ func (c *GoContainer) BuildGoImage() error {
 		os.Exit(1)
 	}
 
-	platforms := types.GetPlatforms(container.GetBuild().Platform)
+	platforms := types.GetPlatforms(c.GetBuild().Platform)
 	slog.Info("Building intermediate image", "image", image, "platforms", platforms)
 	return c.Container.BuildIntermidiateContainer(image, dockerFile, platforms...)
 }
 
 func (c *GoContainer) Build() error {
-	imageTag := GoImage()
+	imageTag := c.GoImage()
 
-	ssh, err := network.SSHForward()
+	ssh, err := network.SSHForward(*c.GetBuild())
 	if err != nil {
 		slog.Error("Failed to forward SSH", "error", err)
 		os.Exit(1)
@@ -313,8 +313,8 @@ func (c *GoContainer) BuildScript() string {
 	return buildscript.NewBuildScript(c.App, c.File, c.Tags, c.Container.Verbose, c.Platforms...).String()
 }
 
-func NewProd() build.Build {
-	container := New()
+func NewProd(build container.Build) build.Build {
+	container := New(build)
 	return GoBuild{
 		rf: func() error {
 			return container.Prod()
@@ -325,6 +325,10 @@ func NewProd() build.Build {
 }
 
 func (c *GoContainer) Prod() error {
+	if c.GetBuild().Env == container.LocalEnv {
+		slog.Info("Skip building prod image in local environment")
+		return nil
+	}
 	if c.Image == "" {
 		slog.Info("Skip No image specified to push")
 		return nil
@@ -388,7 +392,7 @@ func (c *GoContainer) Prod() error {
 		os.Exit(1)
 	}
 
-	imageUri := utils.ImageURI(container.GetBuild().Registry, c.Image, c.ImageTag)
+	imageUri := utils.ImageURI(c.GetBuild().Registry, c.Image, c.ImageTag)
 	err = c.Container.Push(imageId, imageUri, container.PushOption{Remove: false})
 	if err != nil {
 		slog.Error("Failed to push image: %s", "error", err)

--- a/pkg/golang/debiancgo/golang.go
+++ b/pkg/golang/debiancgo/golang.go
@@ -40,24 +40,24 @@ type GoContainer struct {
 	*container.Container
 }
 
-func New() *GoContainer {
-	platforms := []*types.PlatformSpec{container.GetBuild().Platform.Container}
-	if !container.GetBuild().Platform.Same() {
-		slog.Info("Different platform detected", "host", container.GetBuild().Platform.Host, "container", container.GetBuild().Platform.Container)
+func New(build container.Build) *GoContainer {
+	platforms := []*types.PlatformSpec{build.Platform.Container}
+	if !build.Platform.Same() {
+		slog.Info("Different platform detected", "host", build.Platform.Host, "container", build.Platform.Container)
 		platforms = []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")}
 	}
 	return &GoContainer{
-		App:       container.GetBuild().App,
-		Container: container.New(container.BuildEnv),
-		Image:     container.GetBuild().Image,
-		ImageTag:  container.GetBuild().ImageTag,
+		App:       build.App,
+		Container: container.New(build),
+		Image:     build.Image,
+		ImageTag:  build.ImageTag,
 		// TODO: only build multiple platforms when buildenv and localenv are running on different platforms
 		// FIX: linux-arm64 go build is needed when building contains on MacOS M1/M2
 		// Platforms: []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")},
 		Platforms: platforms,
-		File:      container.GetBuild().File,
-		Folder:    container.GetBuild().Folder,
-		Tags:      container.GetBuild().Custom["tags"],
+		File:      build.File,
+		Folder:    build.Folder,
+		Tags:      build.Custom["tags"],
 	}
 }
 
@@ -103,10 +103,10 @@ func (g GoBuild) Name() string     { return g.name }
 func (g GoBuild) Images() []string { return g.images }
 func (g GoBuild) IsAsync() bool    { return g.async }
 
-func NewLinter() build.Build {
+func NewLinter(build container.Build) build.Build {
 	return GoBuild{
 		rf: func() error {
-			container := New()
+			container := New(build)
 			err := container.Container.Pull(LINT_IMAGE)
 			if err != nil {
 				slog.Error("Failed to pull image: %s", "error", err, "image", LINT_IMAGE)
@@ -138,7 +138,7 @@ ssh-keyscan github.com >> ~/.ssh/known_hosts
 git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
 GOOS=%s GOARCH=%s golangci-lint --out-format colored-line-number -v run %s --timeout=5m
 ls -lha /
-`, container.GetBuild().Platform.Container.OS, container.GetBuild().Platform.Container.Architecture, tags)
+`, c.GetBuild().Platform.Container.OS, c.GetBuild().Platform.Container.Architecture, tags)
 	err := c.Container.CopyContentTo(script, "/tmp/script.sh")
 	if err != nil {
 		slog.Error("Failed to copy script to container: %s", "error", err)
@@ -150,7 +150,7 @@ ls -lha /
 func (c *GoContainer) Lint() error {
 	imageTag := LintImage()
 
-	ssh, err := network.SSHForward()
+	ssh, err := network.SSHForward(*c.GetBuild())
 	if err != nil {
 		slog.Error("Failed to forward SSH", "error", err)
 		os.Exit(1)
@@ -221,7 +221,7 @@ func (c *GoContainer) Lint() error {
 	return err
 }
 
-func GoImage() string {
+func (c *GoContainer) GoImage() string {
 	dockerFile, err := f.ReadFile("Dockerfilego")
 	if err != nil {
 		slog.Error("Failed to read Dockerfile.go", "error", err)
@@ -229,17 +229,17 @@ func GoImage() string {
 	}
 	tag := container.ComputeChecksum(dockerFile)
 	image := fmt.Sprintf("golang-%s-cgo", DEFAULT_GO)
-	return utils.ImageURI(container.GetBuild().ContainifyRegistry, image, tag)
+	return utils.ImageURI(c.GetBuild().ContainifyRegistry, image, tag)
 }
 
 func (c *GoContainer) Images() []string {
 	imageTag := fmt.Sprintf("golang-%s-cgo", DEFAULT_GO)
 
-	return []string{imageTag, "alpine:latest", GoImage()}
+	return []string{imageTag, "alpine:latest", c.GoImage()}
 }
 
 func (c *GoContainer) BuildGoImage() error {
-	image := GoImage()
+	image := c.GoImage()
 
 	dockerFile, err := f.ReadFile("Dockerfilego")
 	if err != nil {
@@ -247,15 +247,15 @@ func (c *GoContainer) BuildGoImage() error {
 		os.Exit(1)
 	}
 
-	platforms := types.GetPlatforms(container.GetBuild().Platform)
+	platforms := types.GetPlatforms(c.GetBuild().Platform)
 	slog.Info("Building intermediate image", "image", image, "platforms", platforms)
 	return c.Container.BuildIntermidiateContainer(image, dockerFile, platforms...)
 }
 
 func (c *GoContainer) Build() error {
-	imageTag := GoImage()
+	imageTag := c.GoImage()
 
-	ssh, err := network.SSHForward()
+	ssh, err := network.SSHForward(*c.GetBuild())
 	if err != nil {
 		slog.Error("Failed to forward SSH", "error", err)
 		os.Exit(1)
@@ -311,14 +311,14 @@ func (c *GoContainer) Build() error {
 func (c *GoContainer) BuildScript() string {
 	// Create a temporary script in-memory
 	platforms := c.Platforms
-	if container.GetBuild().Custom.Strings("platforms") != nil {
-		platforms = types.ParsePlatforms(container.GetBuild().Custom.Strings("platforms")...)
+	if c.GetBuild().Custom.Strings("platforms") != nil {
+		platforms = types.ParsePlatforms(c.GetBuild().Custom.Strings("platforms")...)
 	}
 	return buildscript.NewBuildScript(c.App, c.File, c.Tags, c.Container.Verbose, platforms...).String()
 }
 
-func NewProd() build.Build {
-	container := New()
+func NewProd(build container.Build) build.Build {
+	container := New(build)
 	return GoBuild{
 		rf: func() error {
 			return container.Prod()
@@ -329,6 +329,10 @@ func NewProd() build.Build {
 }
 
 func (c *GoContainer) Prod() error {
+	if c.GetBuild().Env == container.LocalEnv {
+		slog.Info("Skip building prod image in local environment")
+		return nil
+	}
 	if c.Image == "" {
 		slog.Info("Skip No image specified to push")
 		return nil
@@ -392,7 +396,7 @@ func (c *GoContainer) Prod() error {
 		os.Exit(1)
 	}
 
-	imageUri := utils.ImageURI(container.GetBuild().Registry, c.Image, c.ImageTag)
+	imageUri := utils.ImageURI(c.GetBuild().Registry, c.Image, c.ImageTag)
 	err = c.Container.Push(imageId, imageUri, container.PushOption{Remove: false})
 	if err != nil {
 		slog.Error("Failed to push image: %s", "error", err)

--- a/pkg/golang/golang.go
+++ b/pkg/golang/golang.go
@@ -2,31 +2,32 @@ package golang
 
 import (
 	"github.com/containifyci/engine-ci/pkg/build"
+	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/golang/alpine"
 	"github.com/containifyci/engine-ci/pkg/golang/debian"
 	"github.com/containifyci/engine-ci/pkg/golang/debiancgo"
 )
 
-func New() *alpine.GoContainer {
-	return alpine.New()
+func New(build container.Build) *alpine.GoContainer {
+	return alpine.New(build)
 }
 
-func NewDebian() *debian.GoContainer {
-	return debian.New()
+func NewDebian(build container.Build) *debian.GoContainer {
+	return debian.New(build)
 }
 
-func NewProdDebian() build.Build {
-	return debian.NewProd()
+func NewProdDebian(build container.Build) build.Build {
+	return debian.NewProd(build)
 }
 
-func NewCGO() *debiancgo.GoContainer {
-	return debiancgo.New()
+func NewCGO(build container.Build) *debiancgo.GoContainer {
+	return debiancgo.New(build)
 }
 
-func NewProd() build.Build {
-	return alpine.NewProd()
+func NewProd(build container.Build) build.Build {
+	return alpine.NewProd(build)
 }
 
-func NewLinter() build.Build {
-	return alpine.NewLinter()
+func NewLinter(build container.Build) build.Build {
+	return alpine.NewLinter(build)
 }

--- a/pkg/goreleaser/goreleaser.go
+++ b/pkg/goreleaser/goreleaser.go
@@ -21,9 +21,9 @@ type GoReleaserContainer struct {
 	*container.Container
 }
 
-func New() *GoReleaserContainer {
+func New(build container.Build) *GoReleaserContainer {
 	return &GoReleaserContainer{
-		Container: container.New(container.BuildEnv),
+		Container: container.New(build),
 	}
 }
 
@@ -65,7 +65,7 @@ func (c *GoReleaserContainer) ApplyEnvs(envs []string) []string {
 }
 
 func (c *GoReleaserContainer) Release(env container.EnvType) error {
-	if container.GetBuild().Custom.Bool("goreleaser") {
+	if c.GetBuild().Custom.Bool("goreleaser") {
 		slog.Info("Skip goreleaser")
 	}
 	token := container.GetEnv("CONTAINIFYCI_GITHUB_TOKEN")
@@ -133,7 +133,7 @@ func (c *GoReleaserContainer) Run() error {
 		slog.Info("Skipping goreleaser for non-main branch")
 		return nil
 	}
-	env := container.GetBuild().Env
+	env := c.GetBuild().Env
 
 	err := c.Pull()
 	if err != nil {

--- a/pkg/kv/api.go
+++ b/pkg/kv/api.go
@@ -13,7 +13,7 @@ import (
 
 type Server struct {
 	Listener net.Listener
-	Port int
+	Port     int
 }
 
 // In-memory key-value store
@@ -56,7 +56,6 @@ func (kv *KeyValueStore) SetVal(key, val string) {
 	kv.store[key] = val
 	kv.mu.Unlock()
 }
-
 
 // Get value by key
 func (kv *KeyValueStore) Get(w http.ResponseWriter, r *http.Request) {

--- a/pkg/network/localhost.go
+++ b/pkg/network/localhost.go
@@ -15,6 +15,7 @@ var RuntimeOS = runtime.GOOS
 type Address struct {
 	Host         string
 	InternalHost string
+	Port         int
 }
 
 func (a *Address) NewAddress(arg *container.Build) {
@@ -62,10 +63,10 @@ func hostname(scheme, host, port string) string {
 	return fmt.Sprintf("%s://%s:%s", scheme, host, port)
 }
 
-func (a *Address) ForContainer(env container.EnvType) string {
-	a.NewAddress(container.GetBuild())
+func (a *Address) ForContainer(build container.Build) string {
+	a.NewAddress(&build)
 
-	switch env {
+	switch build.Env {
 	case container.LocalEnv:
 		return a.InternalHost
 	case container.BuildEnv:
@@ -75,12 +76,7 @@ func (a *Address) ForContainer(env container.EnvType) string {
 	}
 }
 
-func (a *Address) ForContainerDefault(arg ...*container.Build) string {
-	if len(arg) > 0 {
-		a.NewAddress(arg[0])
-	} else {
-		a.NewAddress(container.GetBuild())
-	}
-
+func (a *Address) ForContainerDefault(arg *container.Build) string {
+	a.NewAddress(arg)
 	return a.InternalHost
 }

--- a/pkg/network/localhost_test.go
+++ b/pkg/network/localhost_test.go
@@ -77,10 +77,7 @@ func TestAddress_ForContainer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name+" os "+tt.os+" cri "+string(tt.cri), func(t *testing.T) {
 			RuntimeOS = tt.os
-			container.NewBuild(&container.Build{
-				Runtime: tt.cri,
-			})
-			host := tt.addr.ForContainer(tt.env)
+			host := tt.addr.ForContainer(container.Build{Env: tt.env, Runtime: tt.cri})
 			assert.Equal(t, tt.want, host)
 		})
 	}

--- a/pkg/network/sshforward.go
+++ b/pkg/network/sshforward.go
@@ -36,8 +36,8 @@ func (f *Forward) Apply(opts *types.ContainerConfig) types.ContainerConfig {
 	return *opts
 }
 
-func SSHForward() (*Forward, error) {
-	switch container.GetBuild().Platform.Host.OS {
+func SSHForward(build container.Build) (*Forward, error) {
+	switch build.Platform.Host.OS {
 	case "linux":
 		sshAuthSocket := os.Getenv("SSH_AUTH_SOCK")
 		if sshAuthSocket == "" {
@@ -55,7 +55,7 @@ func SSHForward() (*Forward, error) {
 			},
 		}, nil
 	case "darwin":
-		if container.GetBuild().Runtime == "podman" {
+		if build.Runtime == "podman" {
 			slog.Warn("SSH forwarding is not supported on macOS with Podman")
 			return nil, nil
 		}
@@ -75,5 +75,5 @@ func SSHForward() (*Forward, error) {
 			},
 		}, nil
 	}
-	return nil, fmt.Errorf("unsupported platform: %s", container.GetBuild().Platform.Host)
+	return nil, fmt.Errorf("unsupported platform: %s", build.Platform.Host)
 }

--- a/pkg/network/sshforward_test.go
+++ b/pkg/network/sshforward_test.go
@@ -53,15 +53,15 @@ func TestSSHForward(t *testing.T) {
 	for _, tt := range tests {
 		t.Setenv("SSH_AUTH_SOCK", "linux_ssh_auth_socket")
 		t.Run("test for "+tt.os, func(t *testing.T) {
-			container.NewBuild(&container.Build{
+			build := &container.Build{
 				Runtime: tt.cri,
 				Platform: types.Platform{
 					Host: &types.PlatformSpec{
 						OS: tt.os,
 					},
 				},
-			})
-			got, err := SSHForward()
+			}
+			got, err := SSHForward(*build)
 			if tt.want == nil {
 				assert.Error(t, err)
 			} else {

--- a/pkg/sonarcloud/sonarqube.go
+++ b/pkg/sonarcloud/sonarqube.go
@@ -55,10 +55,10 @@ func (c *SonarqubeContainer) Address() *network.Address {
 	return &network.Address{Host: "https://sonarcloud.io:443", InternalHost: "http://localhost:9000"}
 }
 
-func NewSonarQube() *SonarqubeContainer {
+func NewSonarQube(build container.Build) *SonarqubeContainer {
 	_token := os.Getenv("SONAR_TOKEN")
 	return &SonarqubeContainer{
-		Container: container.New(container.LocalEnv),
+		Container: container.New(build),
 		token:     &_token,
 	}
 }


### PR DESCRIPTION
Refactor the build process in various Go services to streamline and enhance the build and runtime configurations. This includes making structural changes in how build arguments and platform details are handled to improve maintainability and scalability.
 Key changes include reduced reliance on global variables, refactoring
 container initialization, and update in function signatures to
 produce more modular code.

- Refactor build process across multiple Go services
- Reduce reliance on global variables
- Improve container initialization process
- Update function signatures for modular code structure