### PR TITLE
feat(.containify): use parallel builds now

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -28,16 +28,22 @@ func registryAuth() map[string]*protos2.ContainerRegistry {
 func main() {
 
 	os.Chdir("..")
-	protos2 := build.NewGoServiceBuild("engine-ci-protos2")
-	protos2.Folder = "protos2"
-	protos2.Image = ""
+	pr2 := build.NewGoServiceBuild("engine-ci-protos2")
+	pr2.Folder = "protos2"
+	pr2.Image = ""
+	pr2.Properties = map[string]*build.ListValue{
+		"goreleaser": build.NewList("false"),
+	}
 
 	client := build.NewGoServiceBuild("engine-ci-client")
-	client.File = "client.go"
+	client.File = "client/client.go"
 	client.Folder = "client"
 	client.Image = ""
+	client.Properties = map[string]*build.ListValue{
+		"goreleaser": build.NewList("false"),
+	}
 
-	// build.Serve(protos2, client)
+	// build.Serve(pr2, client)
 
 	opts1 := build.NewGoServiceBuild("engine-ci")
 	opts1.File = "main.go"
@@ -56,5 +62,13 @@ func main() {
 	}
 	opts2.Registries = registryAuth()
 	// build.Serve(opts1, opts2)
-	build.Serve(protos2, client, opts1, opts2)
+	// build.Build(pr2, client, opts1, opts2)
+	build.BuildGroups(
+		&protos2.BuildArgsGroup{
+			Args: []*protos2.BuildArgs{pr2, client},
+		},
+		&protos2.BuildArgsGroup{
+			Args: []*protos2.BuildArgs{opts1, opts2},
+		},
+	)
 }

--- a/.containifyci/go.mod
+++ b/.containifyci/go.mod
@@ -5,8 +5,8 @@ go 1.23
 toolchain go1.23.3
 
 require (
-	github.com/containifyci/engine-ci/client v0.6.1
-	github.com/containifyci/engine-ci/protos2 v0.6.0
+	github.com/containifyci/engine-ci/client v0.7.0
+	github.com/containifyci/engine-ci/protos2 v0.7.0
 )
 
 require (

--- a/.containifyci/go.sum
+++ b/.containifyci/go.sum
@@ -1,9 +1,9 @@
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
-github.com/containifyci/engine-ci/client v0.6.1 h1:pCz7WCAF9Ji9ao3oMeb1+9lIa6kobDqO6+SZ5bNKHf4=
-github.com/containifyci/engine-ci/client v0.6.1/go.mod h1:haGjIt54eOg8Ed5vzX/2FKKS+FP6xUXz0WcKTqpNw0U=
-github.com/containifyci/engine-ci/protos2 v0.6.0 h1:1mu02+KmL3bRDEiRDVHczGwqSBhgklWSPjZBzhZWotU=
-github.com/containifyci/engine-ci/protos2 v0.6.0/go.mod h1:zKwCTS2FmCRJwAzdGA1wCYty5EdMhZLx5GRy+K+kyD0=
+github.com/containifyci/engine-ci/client v0.7.0 h1:H8L1MQ9PJ5ZKh69/hrUcnzO0ujvWUcSDtVYy93u6S2k=
+github.com/containifyci/engine-ci/client v0.7.0/go.mod h1:BeeuKrDyOTuPuSF/m0EJ2atsdEFAyRLBKmgVgPvpyzI=
+github.com/containifyci/engine-ci/protos2 v0.7.0 h1:7A5SpC1K7da3eV8GCI7CbA0fPJJDswhPuc50NbBQ7Zw=
+github.com/containifyci/engine-ci/protos2 v0.7.0/go.mod h1:zKwCTS2FmCRJwAzdGA1wCYty5EdMhZLx5GRy+K+kyD0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,9 @@
+issues:
+  exclude-rules:
+    - text: 'shadow: declaration of "(err|ctx)" shadows declaration at'
+      linters: [govet]
 linters-settings:
   govet:
-    # Disable all analyzers.
-    # Default: false
-    # disable-all: true
-    # Enable analyzers by name.
-    # (in addition to default:
-    #   appends, asmdecl, assign, atomic, bools, buildtag, cgocall, composites, copylocks, defers, directive, errorsas,
-    #   framepointer, httpresponse, ifaceassert, loopclosure, lostcancel, nilfunc, printf, shift, sigchanyzer, slog,
-    #   stdmethods, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr,
-    #   unusedresult
-    # ).
-    # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
-    # Default: []
     enable:
       - appends
       - asmdecl
@@ -53,68 +45,8 @@ linters-settings:
       - unsafeptr
       - unusedresult
       - unusedwrite
-    # Enable all analyzers.
-    # Default: false
-    # enable-all: true
-    # Disable analyzers by name.
-    # (in addition to default
-    #   atomicalign, deepequalerrors, fieldalignment, findcall, nilness, reflectvaluecompare, shadow, sortslice,
-    #   timeformat, unusedwrite
-    # ).
-    # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
-    # Default: []
-    # disable:
-    #   - appends
-    #   - asmdecl
-    #   - assign
-    #   - atomic
-    #   - atomicalign
-    #   - bools
-    #   - buildtag
-    #   - cgocall
-    #   - composites
-    #   - copylocks
-    #   - deepequalerrors
-    #   - defers
-    #   - directive
-    #   - errorsas
-    #   - fieldalignment
-    #   - findcall
-    #   - framepointer
-    #   - httpresponse
-    #   - ifaceassert
-    #   - loopclosure
-    #   - lostcancel
-    #   - nilfunc
-    #   - nilness
-    #   - printf
-    #   - reflectvaluecompare
-    #   - shadow
-    #   - shift
-    #   - sigchanyzer
-    #   - slog
-    #   - sortslice
-    #   - stdmethods
-    #   - stringintconv
-    #   - structtag
-    #   - testinggoroutine
-    #   - tests
-    #   - unmarshal
-    #   - unreachable
-    #   - unsafeptr
-    #   - unusedresult
-    #   - unusedwrite
     # Settings per analyzer.
     settings:
-      # Analyzer name, run `go tool vet help` to see all analyzers.
-      printf:
-        # Comma-separated list of print function names to check (in addition to default, see `go tool vet help printf`).
-        # Default: []
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
       shadow:
         # Whether to be strict about shadowing; can be noisy.
         # Default: false

--- a/client/pkg/filesystem/file.go
+++ b/client/pkg/filesystem/file.go
@@ -9,8 +9,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var osStat = os.Stat
-
 type FileCache struct {
 	cache       bool
 	fileName    string

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -56,7 +56,7 @@ func init() {
 
 func SaveCache() error {
 	args := GetBuild()
-	_, bs := Pre(args[0])
+	_, bs := Pre(args[0].Builds[0])
 	images := bs.Images()
 	if len(images) == 0 {
 		return nil
@@ -96,7 +96,7 @@ docker save -o ~/image-cache/%s.tar %s
 
 func LoadCache() error {
 	args := GetBuild()
-	arg, bs := Pre(args[0])
+	arg, bs := Pre(args[0].Builds[0])
 
 	images := bs.Images()
 	if len(images) == 0 {

--- a/cmd/engine.go
+++ b/cmd/engine.go
@@ -193,10 +193,12 @@ func GetBuild() container.BuildGroups {
 func CallPlugin(logger hclog.Logger, plugin interface{}) []*protos2.BuildArgsGroup {
 	// We should have a Counter store now! This feels like a normal interface
 	// implementation but is in fact over an RPC connection.
-	containifyci, ok := plugin.(protos2.ContainifyCIv2)
-	if ok {
-		resp := containifyci.GetBuilds()
-		return resp.Args
+	{
+		containifyci, ok := plugin.(protos2.ContainifyCIv2)
+		if ok {
+			resp := containifyci.GetBuilds()
+			return resp.Args
+		}
 	}
 	{
 		containifyci, ok := plugin.(protos2.ContainifyCIv1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"log/slog"
-	"sync"
 
 	"github.com/containifyci/engine-ci/pkg/logger"
 
@@ -11,9 +10,9 @@ import (
 )
 
 type rootCmdArgs struct {
-	Verbose  bool
 	Progress string
 	Target   string
+	Verbose  bool
 }
 
 var RootArgs = &rootCmdArgs{}
@@ -48,8 +47,6 @@ to quickly create a Cobra application.`,
 		logger.GetLogAggregator().Flush()
 	},
 }
-
-var mu sync.Mutex
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.

--- a/go.mod
+++ b/go.mod
@@ -3,30 +3,25 @@ module github.com/containifyci/engine-ci
 go 1.23
 
 require (
+	cloud.google.com/go/iam v1.2.2
 	github.com/containers/buildah v1.38.0
 	github.com/containers/common v0.61.0
 	github.com/containers/podman/v5 v5.3.1
-	github.com/containifyci/engine-ci/protos2 v0.6.0
+	github.com/containifyci/engine-ci/protos2 v0.7.0
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/dusted-go/logging v1.3.0
 	github.com/gorilla/mux v1.8.1
-	//CVE-2024-37298 fix
-	github.com/gorilla/schema v1.4.1 // indirect
 	github.com/gorilla/websocket v1.5.3
+	github.com/hashicorp/go-hclog v1.6.3
+	github.com/hashicorp/go-plugin v1.6.2
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
-	gopkg.in/yaml.v3 v3.0.1
-)
-
-require (
-	cloud.google.com/go/iam v1.2.2
-	github.com/hashicorp/go-hclog v1.6.3
-	github.com/hashicorp/go-plugin v1.6.2
 	golang.org/x/oauth2 v0.24.0
 	google.golang.org/api v0.209.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -90,6 +85,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.0 // indirect
+	github.com/gorilla/schema v1.4.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/containers/psgo v1.9.0 h1:eJ74jzSaCHnWt26OlKZROSyUyRcGDf+gYBdXnxrMW4g
 github.com/containers/psgo v1.9.0/go.mod h1:0YoluUm43Mz2UnBIh1P+6V6NWcbpTL5uRtXyOcH0B5A=
 github.com/containers/storage v1.56.0 h1:DZ9KSkj6M2tvj/4bBoaJu3QDHRl35BwsZ4kmLJS97ZI=
 github.com/containers/storage v1.56.0/go.mod h1:c6WKowcAlED/DkWGNuL9bvGYqIWCVy7isRMdCSKWNjk=
-github.com/containifyci/engine-ci/protos2 v0.6.0 h1:1mu02+KmL3bRDEiRDVHczGwqSBhgklWSPjZBzhZWotU=
-github.com/containifyci/engine-ci/protos2 v0.6.0/go.mod h1:zKwCTS2FmCRJwAzdGA1wCYty5EdMhZLx5GRy+K+kyD0=
+github.com/containifyci/engine-ci/protos2 v0.7.0 h1:7A5SpC1K7da3eV8GCI7CbA0fPJJDswhPuc50NbBQ7Zw=
+github.com/containifyci/engine-ci/protos2 v0.7.0/go.mod h1:zKwCTS2FmCRJwAzdGA1wCYty5EdMhZLx5GRy+K+kyD0=
 github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09 h1:OoRAFlvDGCUqDLampLQjk0yeeSGdF9zzst/3G9IkBbc=
 github.com/coreos/go-systemd/v22 v22.5.1-0.20231103132048-7d375ecc2b09/go.mod h1:m2r/smMKsKwgMSAoFKHaa68ImdCSNuKE1MxvQ64xuCQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -26,9 +26,9 @@ type Build interface {
 type RunFunc func() error
 
 type BuildSteps struct {
-	init  bool
 	Steps []*BuildContext
 	build container.Build
+	init  bool
 }
 
 func ToBuildContexts(steps ...Build) []*BuildContext {

--- a/pkg/container/build.go
+++ b/pkg/container/build.go
@@ -116,6 +116,12 @@ type Build struct {
 	Leader   Leader
 }
 
+type BuildGroup struct {
+	Builds []*Build
+}
+
+type BuildGroups []*BuildGroup
+
 func (b *Build) CustomString(key string) string {
 	if v, ok := b.Custom[key]; ok {
 		if len(v) == 1 {

--- a/pkg/container/build.go
+++ b/pkg/container/build.go
@@ -89,31 +89,26 @@ type Leader interface {
 
 // TODO: add target container platform
 type Build struct {
-	App      string `json:"app"`
-	Env      EnvType
-	File     string
-	Folder   string
-	Image    string `json:"image"`
-	ImageTag string `json:"image_tag"`
-	Custom   Custom
-
-	BuildType BuildType `json:"build_type"`
-	// docker or podman
-	Runtime utils.RuntimeType
-
-	Organization       string
+	Leader             Leader
 	Platform           types.Platform
+	Custom             Custom
+	Registries         map[string]*protos2.ContainerRegistry
+	Folder             string
+	App                string    `json:"app"`
+	Image              string    `json:"image"`
+	BuildType          BuildType `json:"build_type"`
+	Runtime            utils.RuntimeType
+	Organization       string
+	ImageTag           string `json:"image_tag"`
 	Registry           string
 	ContainifyRegistry string
+	Env                EnvType
+	File               string
 	Repository         string
 	SourcePackages     []string
 	SourceFiles        []string
 	Verbose            bool
-	Registries         map[string]*protos2.ContainerRegistry
-
-	//internal variables
-	defaults bool
-	Leader   Leader
+	defaults           bool
 }
 
 type BuildGroup struct {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -67,20 +67,16 @@ func (e *EnvType) Type() string {
 }
 
 type Container struct {
-	// private fields
+	t
+	Source  fs.ReadDirFS
+	Build   *Build
 	ID      string
 	Name    string
 	Image   string
 	Env     EnvType
+	Prefix  string
+	Opts    types.ContainerConfig
 	Verbose bool
-
-	Source fs.ReadDirFS
-
-	Opts   types.ContainerConfig
-	Prefix string
-	t
-
-	Build *Build
 }
 
 type PushOption struct {

--- a/pkg/container/errors_test.go
+++ b/pkg/container/errors_test.go
@@ -1,7 +1,7 @@
 package container
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,5 +35,5 @@ func TestHasSamePrefix(t *testing.T) {
 }
 
 func NewError(message string) error {
-	return fmt.Errorf(message)
+	return errors.New(message)
 }

--- a/pkg/cri/critest/critest.go
+++ b/pkg/cri/critest/critest.go
@@ -23,15 +23,15 @@ type MockContainerManager struct {
 	Containers           map[string]*MockContainerLifecycle
 	ContainerLogsEntries map[string][]string
 	Images               map[string]*MockImageLifecycle
-	ImagesLogEntries     []string
 	Errors               map[string]error
+	ImagesLogEntries     []string
 }
 
 type MockContainerLifecycle struct {
-	ID     string
 	Opts   *types.ContainerConfig
-	State  string
 	Volume *MockContainerVolume
+	ID     string
+	State  string
 }
 
 type MockContainerVolume struct {
@@ -146,7 +146,8 @@ func (m *MockContainerManager) ContainerLogs(ctx context.Context, id string, sho
 		return nil, ErrContainerNotFound
 	}
 
-	if logs, exists := m.ContainerLogsEntries[con.Opts.Image]; exists {
+	logs, exists := m.ContainerLogsEntries[con.Opts.Image]
+	if exists {
 		return io.NopCloser(strings.NewReader(strings.Join(logs, "\n"))), nil
 	}
 	return nil, ErrContainerNotFound

--- a/pkg/cri/docker/docker.go
+++ b/pkg/cri/docker/docker.go
@@ -117,7 +117,7 @@ func (d *DockerManager) CreateContainer(ctx context.Context, opts *types.Contain
 			return "", err
 		}
 		defer r.Close()
-		logger.GetLogAggregator().Copy(r)
+		_, err = logger.GetLogAggregator().Copy(r)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cri/host/host.go
+++ b/pkg/cri/host/host.go
@@ -155,7 +155,7 @@ func (d *HostManager) CopyContentToContainer(ctx context.Context, id, content, d
 			os.Exit(1)
 		}
 		dest = fmt.Sprintf("/tmp/%s/script.sh", id)
-		content := strings.ReplaceAll(content, c.opts.WorkingDir+"/", "")
+		content = strings.ReplaceAll(content, c.opts.WorkingDir+"/", "")
 		return os.WriteFile(dest, []byte(content), 0755)
 	}
 	os.Exit(1)

--- a/pkg/cri/podman/podman.go
+++ b/pkg/cri/podman/podman.go
@@ -655,9 +655,9 @@ func (p *PodmanManager) BuildImage(ctx context.Context, dockerfile []byte, image
 // BuildImage builds an image
 func (p *PodmanManager) BuildMultiArchImage(ctx context.Context, dockerfile []byte, dockerCtx *bytes.Buffer, imageName string, platforms []string, _ string) (io.ReadCloser, []string, error) {
 	imageIDs := []struct {
+		Platform *types.PlatformSpec
 		ID       *string
 		Image    string
-		Platform *types.PlatformSpec
 	}{}
 	// Create a temporary directory for the Dockerfile
 	dir, err := os.MkdirTemp("", "podman-build")
@@ -735,9 +735,9 @@ func (p *PodmanManager) BuildMultiArchImage(ctx context.Context, dockerfile []by
 				os.Exit(1)
 			}
 			imageIDs = append(imageIDs, struct {
+				Platform *types.PlatformSpec
 				ID       *string
 				Image    string
-				Platform *types.PlatformSpec
 			}{
 				ID:       &res.ID,
 				Image:    tmpImageName,
@@ -754,9 +754,9 @@ func (p *PodmanManager) BuildMultiArchImage(ctx context.Context, dockerfile []by
 			os.Exit(1)
 		}
 		imageIDs = append(imageIDs, struct {
+			Platform *types.PlatformSpec
 			ID       *string
 			Image    string
-			Platform *types.PlatformSpec
 		}{
 			ID:    &res.ID,
 			Image: imageName,

--- a/pkg/cri/types/container.go
+++ b/pkg/cri/types/container.go
@@ -4,9 +4,9 @@ import "time"
 
 type Container struct {
 	ID      string
-	Names   []string
 	Image   string
 	ImageID string
+	Names   []string
 }
 
 type PortBinding struct {
@@ -27,30 +27,48 @@ type Binding struct {
 }
 
 type ReadinessProbe struct {
+	Validate func([]byte) bool
 	Endpoint string
 	Timeout  time.Duration
-	Validate func([]byte) bool
 }
 
 type ContainerConfig struct {
+	ExposedPorts []Binding
+	Volumes      []Volume // List of volumes (mounts) used for the container
+	Platform     *Platform
+	Readiness    *ReadinessProbe `json:"-"`
+	Image        string          // Name of the image as it was passed by the operator (e.g., could be symbolic)
+	Name         string
+	Script       string
+	User         string // User that will run the command(s) inside the container, also supports user:group
+	WorkingDir   string // Current directory (PWD) in which the command will be launched
 	Cmd          []string
 	Entrypoint   []string
 	Env          []string // List of environment variable to set in the container
-	ExposedPorts []Binding
-	Image        string // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Name         string
-	Platform     *Platform
-	Readiness    *ReadinessProbe `json:"-"`
-	Tty          bool            // Attach standard streams to a tty, including stdin if it is not closed.
-	User         string          // User that will run the command(s) inside the container, also support user:group
-	Volumes      []Volume        // List of volumes (mounts) used for the container
-	WorkingDir   string          // Current directory (PWD) in the command will be launched
 	Memory       int64
 	CPU          uint64
-	Script       string
+	Tty          bool // Attach standard streams to a tty, including stdin if it is not closed
 }
 
+// type ContainerConfig struct {
+// 	Platform     *Platform
+// 	Readiness    *ReadinessProbe `json:"-"`
+// 	Tty          bool            // Attach standard streams to a tty, including stdin if it is not closed.
+// 	Memory       int64
+// 	CPU          uint64
+// 	User         string          // User that will run the command(s) inside the container, also support user:group
+// 	WorkingDir   string          // Current directory (PWD) in the command will be launched
+// 	Image        string // Name of the image as it was passed by the operator (e.g. could be symbolic)
+// 	Name         string
+// 	Script       string
+// 	Cmd          []string
+// 	Entrypoint   []string
+// 	Env          []string // List of environment variable to set in the container
+// 	Volumes      []Volume        // List of volumes (mounts) used for the container
+// 	ExposedPorts []Binding
+// }
+
 type ImageInfo struct {
-	ID       string
 	Platform *PlatformSpec
+	ID       string
 }

--- a/pkg/cri/types/errors_test.go
+++ b/pkg/cri/types/errors_test.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,5 +35,5 @@ func TestHasSamePrefix(t *testing.T) {
 }
 
 func NewError(message string) error {
-	return fmt.Errorf(message)
+	return errors.New(message)
 }

--- a/pkg/filesystem/file.go
+++ b/pkg/filesystem/file.go
@@ -47,9 +47,9 @@ func DirectoryExists(dirName string) error {
 }
 
 type FileCache struct {
-	cache       bool
-	fileName    string
 	FileResults map[string]FileResult `yaml:"file_results"`
+	fileName    string
+	cache       bool
 }
 
 type FileResult struct {

--- a/pkg/gcloud/oidc.go
+++ b/pkg/gcloud/oidc.go
@@ -29,8 +29,8 @@ const (
 )
 
 type GCloudContainer struct {
-	applicationCredentials string
 	*container.Container
+	applicationCredentials string
 }
 
 func New(build container.Build) *GCloudContainer {

--- a/pkg/golang/alpine/golang.go
+++ b/pkg/golang/alpine/golang.go
@@ -270,7 +270,8 @@ func (c *GoContainer) Build() error {
 
 	opts.WorkingDir = "/src"
 
-	dir, _ := filepath.Abs(c.Folder)
+	// dir, _ := filepath.Abs(c.Folder)
+	dir, _ := filepath.Abs(".")
 
 	cache := CacheFolder()
 	if cache == "" {
@@ -309,7 +310,7 @@ func (c *GoContainer) Build() error {
 
 func (c *GoContainer) BuildScript() string {
 	// Create a temporary script in-memory
-	return buildscript.NewBuildScript(c.App, c.File, c.Tags, c.Container.Verbose, c.Platforms...).String()
+	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, c.Platforms...).String()
 }
 
 func NewProd(build container.Build) build.Build {

--- a/pkg/golang/buildscript/buildscript.go
+++ b/pkg/golang/buildscript/buildscript.go
@@ -14,27 +14,32 @@ import (
 type Image string
 
 type BuildScript struct {
-	Tags      []string
-	AppName   string
-	MainFile  string
-	Output    string
-	Platforms []*types.PlatformSpec
-	Verbose   bool
+	Tags       []string
+	AppName    string
+	MainFile   string
+	Folder     string
+	Output     string
+	Platforms  []*types.PlatformSpec
+	Verbose    bool
 }
 
-func NewBuildScript(appName, mainfile string, tags []string, verbose bool, platforms ...*types.PlatformSpec) *BuildScript {
+func NewBuildScript(appName, mainfile string, folder string, tags []string, verbose bool, platforms ...*types.PlatformSpec) *BuildScript {
 	output := "-o /src/{{.app}}-{{.os}}-{{.arch}}"
 	if mainfile == "" {
 		mainfile = "./..."
 		output = ""
 	}
+	if folder == "" {
+		folder = "."
+	}
 	script := &BuildScript{
-		AppName:   appName,
-		MainFile:  mainfile,
-		Output:    output,
-		Platforms: platforms,
-		Tags:      tags,
-		Verbose:   verbose,
+		AppName:    appName,
+		MainFile:   mainfile,
+		Folder:     folder,
+		Output:     output,
+		Platforms:  platforms,
+		Tags:       tags,
+		Verbose:    verbose,
 	}
 	return script
 }
@@ -51,8 +56,9 @@ set -xe
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
+cd %s
 %s
-`, goBuildCmd)
+`, bs.Folder, goBuildCmd)
 
 	return script
 }

--- a/pkg/golang/buildscript/buildscript_test.go
+++ b/pkg/golang/buildscript/buildscript_test.go
@@ -9,12 +9,13 @@ import (
 )
 
 func TestVerboseScript(t *testing.T) {
-	bs := NewBuildScript("test", "/src/main.go", []string{"build_tag"}, true, types.ParsePlatform("linux/amd64"), types.ParsePlatform("darwin/arm64"))
+	bs := NewBuildScript("test", "/src/main.go", "", []string{"build_tag"}, true, types.ParsePlatform("linux/amd64"), types.ParsePlatform("darwin/arm64"))
 	expected := `#!/bin/sh
 set -xe
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
+cd .
 env GOOS=linux GOARCH=amd64 go build -tags build_tag -x -o /src/test-linux-amd64 /src/main.go
 env GOOS=darwin GOARCH=arm64 go build -tags build_tag -x -o /src/test-darwin-arm64 /src/main.go
 go test -v -timeout 120s -tags build_tag -cover -coverprofile coverage.txt ./...
@@ -24,13 +25,14 @@ go test -v -timeout 120s -tags build_tag -cover -coverprofile coverage.txt ./...
 }
 
 func TestSimpleScript(t *testing.T) {
-	bs := NewBuildScript("test", "/src/main.go", nil, false, types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/amd64"))
+	bs := NewBuildScript("test", "/src/main.go","/src", nil, false, types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/amd64"))
 
 	expected := `#!/bin/sh
 set -xe
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
+cd /src
 env GOOS=darwin GOARCH=arm64 go build -o /src/test-darwin-arm64 /src/main.go
 env GOOS=linux GOARCH=amd64 go build -o /src/test-linux-amd64 /src/main.go
 go test -timeout 120s -cover -coverprofile coverage.txt ./...

--- a/pkg/golang/debian/golang.go
+++ b/pkg/golang/debian/golang.go
@@ -8,13 +8,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/containifyci/engine-ci/pkg/build"
-	"github.com/containifyci/engine-ci/pkg/golang/buildscript"
 	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/cri/types"
 	"github.com/containifyci/engine-ci/pkg/cri/utils"
+	"github.com/containifyci/engine-ci/pkg/golang/buildscript"
 	"github.com/containifyci/engine-ci/pkg/network"
 )
 
@@ -30,14 +29,14 @@ var f embed.FS
 
 type GoContainer struct {
 	//TODO add option to fail on linter or not
+	*container.Container
 	App       string
 	File      string
 	Folder    string
 	Image     string
 	ImageTag  string
-	Platforms []*types.PlatformSpec
 	Tags      []string
-	*container.Container
+	Platforms []*types.PlatformSpec
 }
 
 func New(build container.Build) *GoContainer {
@@ -102,124 +101,6 @@ func (g GoBuild) Run() error       { return g.rf() }
 func (g GoBuild) Name() string     { return g.name }
 func (g GoBuild) Images() []string { return g.images }
 func (g GoBuild) IsAsync() bool    { return g.async }
-
-func NewLinter(build container.Build) build.Build {
-	return GoBuild{
-		rf: func() error {
-			container := New(build)
-			err := container.Container.Pull(LINT_IMAGE)
-			if err != nil {
-				slog.Error("Failed to pull image: %s", "error", err, "image", LINT_IMAGE)
-				os.Exit(1)
-			}
-
-			return container.Lint()
-		},
-		name:   "golangci-lint",
-		images: []string{LINT_IMAGE},
-		async:  false,
-	}
-}
-
-func LintImage() string {
-	return LINT_IMAGE
-}
-
-func (c *GoContainer) CopyLintScript() error {
-	tags := ""
-	if len(c.Tags) > 0 {
-		// c.Tags = append(c.Tags, "linux")
-		tags = "--build-tags " + strings.Join(c.Tags, ",")
-	}
-	script := fmt.Sprintf(`#!/bin/sh
-set -x
-mkdir -p ~/.ssh
-ssh-keyscan github.com >> ~/.ssh/known_hosts
-git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
-GOOS=%s GOARCH=%s golangci-lint --out-format colored-line-number -v run %s --timeout=5m
-ls -lha /
-`, c.GetBuild().Platform.Container.OS, c.GetBuild().Platform.Container.Architecture, tags)
-	err := c.Container.CopyContentTo(script, "/tmp/script.sh")
-	if err != nil {
-		slog.Error("Failed to copy script to container: %s", "error", err)
-		os.Exit(1)
-	}
-	return err
-}
-
-func (c *GoContainer) Lint() error {
-	imageTag := LintImage()
-
-	ssh, err := network.SSHForward(*c.GetBuild())
-	if err != nil {
-		slog.Error("Failed to forward SSH", "error", err)
-		os.Exit(1)
-	}
-
-	opts := types.ContainerConfig{}
-	opts.Image = imageTag
-	opts.Env = append(opts.Env, []string{
-		"GOMODCACHE=/go/pkg/",
-		"GOCACHE=/go/pkg/build-cache",
-		"GOLANGCI_LINT_CACHE=/go/pkg/lint-cache",
-	}...)
-	opts.Cmd = []string{"sh", "/tmp/script.sh"}
-	// opts.User = "golangci-lint"
-	if c.Container.Verbose {
-		opts.Cmd = append(opts.Cmd, "-v")
-	}
-	// opts.Platform = "auto"
-	opts.WorkingDir = "/src"
-
-	dir, _ := filepath.Abs(".")
-	cache := CacheFolder()
-	if cache == "" {
-		cache, _ = filepath.Abs(".tmp/go")
-	}
-	opts.Volumes = []types.Volume{
-		{
-			Type:   "bind",
-			Source: dir,
-			Target: "/src",
-		},
-		{
-			Type:   "bind",
-			Source: cache,
-			Target: "/go/pkg",
-		},
-	}
-
-	opts = ssh.Apply(&opts)
-
-	err = c.Container.Create(opts)
-	slog.Info("Container created", "containerId", c.Container.ID)
-	if err != nil {
-		slog.Error("Failed to create container: %s", "error", err)
-		os.Exit(1)
-	}
-
-	err = c.CopyLintScript()
-	if err != nil {
-		slog.Error("Failed to start container", "error", err)
-		os.Exit(1)
-	}
-
-	err = c.Container.Start()
-	if err != nil {
-		slog.Error("Failed to start container: %s", "error", err)
-		os.Exit(1)
-	}
-
-	err = c.Container.Wait()
-	if err != nil {
-		slog.Error("Failed to wait for container: %s", "error", err)
-		// GIVE time to receive all logs
-		time.Sleep(5 * time.Second)
-		os.Exit(1)
-	}
-
-	return err
-}
 
 func (c *GoContainer) GoImage() string {
 	dockerFile, err := f.ReadFile("Dockerfilego")

--- a/pkg/golang/debian/golang.go
+++ b/pkg/golang/debian/golang.go
@@ -310,7 +310,7 @@ func (c *GoContainer) Build() error {
 
 func (c *GoContainer) BuildScript() string {
 	// Create a temporary script in-memory
-	return buildscript.NewBuildScript(c.App, c.File, c.Tags, c.Container.Verbose, c.Platforms...).String()
+	return buildscript.NewBuildScript(c.App, c.File, c.Folder,c.Tags, c.Container.Verbose, c.Platforms...).String()
 }
 
 func NewProd(build container.Build) build.Build {

--- a/pkg/golang/debiancgo/golang.go
+++ b/pkg/golang/debiancgo/golang.go
@@ -314,7 +314,7 @@ func (c *GoContainer) BuildScript() string {
 	if c.GetBuild().Custom.Strings("platforms") != nil {
 		platforms = types.ParsePlatforms(c.GetBuild().Custom.Strings("platforms")...)
 	}
-	return buildscript.NewBuildScript(c.App, c.File, c.Tags, c.Container.Verbose, platforms...).String()
+	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, platforms...).String()
 }
 
 func NewProd(build container.Build) build.Build {

--- a/pkg/golang/debiancgo/golang.go
+++ b/pkg/golang/debiancgo/golang.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/containifyci/engine-ci/pkg/build"
 	"github.com/containifyci/engine-ci/pkg/container"
@@ -30,6 +29,7 @@ var f embed.FS
 
 type GoContainer struct {
 	//TODO add option to fail on linter or not
+	*container.Container
 	App       string
 	File      string
 	Folder    string
@@ -37,7 +37,6 @@ type GoContainer struct {
 	ImageTag  string
 	Platforms []*types.PlatformSpec
 	Tags      []string
-	*container.Container
 }
 
 func New(build container.Build) *GoContainer {
@@ -102,124 +101,6 @@ func (g GoBuild) Run() error       { return g.rf() }
 func (g GoBuild) Name() string     { return g.name }
 func (g GoBuild) Images() []string { return g.images }
 func (g GoBuild) IsAsync() bool    { return g.async }
-
-func NewLinter(build container.Build) build.Build {
-	return GoBuild{
-		rf: func() error {
-			container := New(build)
-			err := container.Container.Pull(LINT_IMAGE)
-			if err != nil {
-				slog.Error("Failed to pull image: %s", "error", err, "image", LINT_IMAGE)
-				os.Exit(1)
-			}
-
-			return container.Lint()
-		},
-		name:   "golangci-lint",
-		images: []string{LINT_IMAGE},
-		async:  false,
-	}
-}
-
-func LintImage() string {
-	return LINT_IMAGE
-}
-
-func (c *GoContainer) CopyLintScript() error {
-	tags := ""
-	if len(c.Tags) > 0 {
-		// c.Tags = append(c.Tags, "linux")
-		tags = "--build-tags " + strings.Join(c.Tags, ",")
-	}
-	script := fmt.Sprintf(`#!/bin/sh
-set -x
-mkdir -p ~/.ssh
-ssh-keyscan github.com >> ~/.ssh/known_hosts
-git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
-GOOS=%s GOARCH=%s golangci-lint --out-format colored-line-number -v run %s --timeout=5m
-ls -lha /
-`, c.GetBuild().Platform.Container.OS, c.GetBuild().Platform.Container.Architecture, tags)
-	err := c.Container.CopyContentTo(script, "/tmp/script.sh")
-	if err != nil {
-		slog.Error("Failed to copy script to container: %s", "error", err)
-		os.Exit(1)
-	}
-	return err
-}
-
-func (c *GoContainer) Lint() error {
-	imageTag := LintImage()
-
-	ssh, err := network.SSHForward(*c.GetBuild())
-	if err != nil {
-		slog.Error("Failed to forward SSH", "error", err)
-		os.Exit(1)
-	}
-
-	opts := types.ContainerConfig{}
-	opts.Image = imageTag
-	opts.Env = append(opts.Env, []string{
-		"GOMODCACHE=/go/pkg/",
-		"GOCACHE=/go/pkg/build-cache",
-		"GOLANGCI_LINT_CACHE=/go/pkg/lint-cache",
-	}...)
-	opts.Cmd = []string{"sh", "/tmp/script.sh"}
-	// opts.User = "golangci-lint"
-	if c.Container.Verbose {
-		opts.Cmd = append(opts.Cmd, "-v")
-	}
-	// opts.Platform = "auto"
-	opts.WorkingDir = "/src"
-
-	dir, _ := filepath.Abs(".")
-	cache := CacheFolder()
-	if cache == "" {
-		cache, _ = filepath.Abs(".tmp/go")
-	}
-	opts.Volumes = []types.Volume{
-		{
-			Type:   "bind",
-			Source: dir,
-			Target: "/src",
-		},
-		{
-			Type:   "bind",
-			Source: cache,
-			Target: "/go/pkg",
-		},
-	}
-
-	opts = ssh.Apply(&opts)
-
-	err = c.Container.Create(opts)
-	slog.Info("Container created", "containerId", c.Container.ID)
-	if err != nil {
-		slog.Error("Failed to create container: %s", "error", err)
-		os.Exit(1)
-	}
-
-	err = c.CopyLintScript()
-	if err != nil {
-		slog.Error("Failed to start container", "error", err)
-		os.Exit(1)
-	}
-
-	err = c.Container.Start()
-	if err != nil {
-		slog.Error("Failed to start container: %s", "error", err)
-		os.Exit(1)
-	}
-
-	err = c.Container.Wait()
-	if err != nil {
-		slog.Error("Failed to wait for container: %s", "error", err)
-		// GIVE time to receive all logs
-		time.Sleep(5 * time.Second)
-		os.Exit(1)
-	}
-
-	return err
-}
 
 func (c *GoContainer) GoImage() string {
 	dockerFile, err := f.ReadFile("Dockerfilego")

--- a/pkg/kv/api.go
+++ b/pkg/kv/api.go
@@ -67,7 +67,10 @@ func (kv *KeyValueStore) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write([]byte(value))
+	_, err := w.Write([]byte(value))
+	if err != nil {
+		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+	}
 }
 
 // Set value for a key

--- a/pkg/maven/maven.go
+++ b/pkg/maven/maven.go
@@ -29,13 +29,13 @@ const (
 var f embed.FS
 
 type MavenContainer struct {
+	Platform types.Platform
+	*container.Container
 	App      string
 	File     string
 	Folder   string
 	Image    string
 	ImageTag string
-	Platform types.Platform
-	*container.Container
 }
 
 func New(build container.Build) *MavenContainer {
@@ -49,7 +49,7 @@ func New(build container.Build) *MavenContainer {
 	}
 }
 
-func (c *MavenContainer) IsAsync () bool {
+func (c *MavenContainer) IsAsync() bool {
 	return false
 }
 
@@ -205,13 +205,13 @@ type MavenBuild struct {
 	rf     build.RunFunc
 	name   string
 	images []string
-	async bool
+	async  bool
 }
 
-func (g MavenBuild) Run() error { return g.rf() }
-func (g MavenBuild) Name() string { return g.name }
+func (g MavenBuild) Run() error       { return g.rf() }
+func (g MavenBuild) Name() string     { return g.name }
 func (g MavenBuild) Images() []string { return g.images }
-func (g MavenBuild) IsAsync() bool { return g.async }
+func (g MavenBuild) IsAsync() bool    { return g.async }
 
 func NewProd(build container.Build) build.Build {
 	container := New(build)
@@ -221,7 +221,7 @@ func NewProd(build container.Build) build.Build {
 		},
 		name:   "maven-prod",
 		images: []string{ProdImage},
-		async: false,
+		async:  false,
 	}
 }
 

--- a/pkg/network/localhost_test.go
+++ b/pkg/network/localhost_test.go
@@ -14,9 +14,9 @@ func TestAddress_ForContainer(t *testing.T) {
 		name string
 		os   string
 		cri  utils.RuntimeType
-		addr Address
 		env  container.EnvType
 		want string
+		addr Address
 	}{
 		{
 			name: "Local URL",

--- a/pkg/network/sshforward.go
+++ b/pkg/network/sshforward.go
@@ -14,10 +14,10 @@ const (
 )
 
 type Forward struct {
+	Volume *types.Volume
 	Source string
 	Target string
 	Env    string
-	Volume *types.Volume
 }
 
 // TODO implement ssh socket forward with

--- a/pkg/network/sshforward_test.go
+++ b/pkg/network/sshforward_test.go
@@ -12,9 +12,9 @@ import (
 func TestSSHForward(t *testing.T) {
 	// Todo: add test for podman runtime
 	tests := []struct {
+		want *Forward
 		os   string
 		cri  utils.RuntimeType
-		want *Forward
 	}{
 		{
 			os:  "linux",

--- a/pkg/protobuf/buildscript.go
+++ b/pkg/protobuf/buildscript.go
@@ -12,10 +12,10 @@ import (
 
 type BuildScript struct {
 	Command        string
-	WithHttp       bool
-	WithTag        bool
 	TargetPackages []string
 	SourceFiles    []string
+	WithHttp       bool
+	WithTag        bool
 }
 
 func NewBuildScript(Command string, SourcePackages, SourceFiles []string, WithHttp, WithTag bool) *BuildScript {

--- a/pkg/protobuf/protobuf.go
+++ b/pkg/protobuf/protobuf.go
@@ -17,12 +17,12 @@ import (
 var f embed.FS
 
 type ProtogufContainer struct {
+	*container.Container
 	Command        string
-	WithHttp       bool
-	WithTag        bool
 	SourcePackages []string
 	SourceFiles    []string
-	*container.Container
+	WithHttp       bool
+	WithTag        bool
 }
 
 func New(build container.Build) *ProtogufContainer {

--- a/pkg/python/python.go
+++ b/pkg/python/python.go
@@ -28,13 +28,13 @@ const (
 var f embed.FS
 
 type PythonContainer struct {
+	Platform types.Platform
+	*container.Container
 	App      string
 	File     string
 	Folder   string
 	Image    string
 	ImageTag string
-	Platform types.Platform
-	*container.Container
 }
 
 func New(build container.Build) *PythonContainer {
@@ -84,7 +84,7 @@ func ComputeChecksum(data []byte) string {
 	return hex.EncodeToString(hash[:])
 }
 
-func  (c *PythonContainer) PythonImage() string {
+func (c *PythonContainer) PythonImage() string {
 	dockerFile, err := f.ReadFile("Dockerfile.python")
 	if err != nil {
 		slog.Error("Failed to read Dockerfile.Python", "error", err)

--- a/pkg/sonarcloud/sonarcloud.go
+++ b/pkg/sonarcloud/sonarcloud.go
@@ -67,10 +67,10 @@ func CacheFolder() string {
 
 func (c *SonarcloudContainer) CopyScript() error {
 	// Create a temporary script in-memory
-	script := `#!/bin/sh
+	script := fmt.Sprintf(`#!/bin/sh
 set -xe
-sonar-scanner -X -Dsonar.projectBaseDir=/usr/src -Dsonar.working.directory=/tmp/sonar
-`
+sonar-scanner -X -Dsonar.projectBaseDir=/usr/src/%s -Dsonar.working.directory=/tmp/sonar
+`, c.Build.Folder)
 	err := c.Container.CopyContentTo(script, "/tmp/script.sh")
 	if err != nil {
 		slog.Error("Failed to copy script to container: %s", "error", err)

--- a/pkg/svc/git.go
+++ b/pkg/svc/git.go
@@ -27,8 +27,8 @@ func (g *Git) FullRepo() string {
 
 // CustomError is a basic custom error type.
 type GitError struct {
-	Code    int
 	Message string
+	Code    int
 }
 
 const (

--- a/pkg/svc/git_test.go
+++ b/pkg/svc/git_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 type GitTestCommand struct {
+	err       error
 	branch    string
 	tag       string
-	exists    bool
 	remoteURL string
-	err       error
+	exists    bool
 }
 
 func (g *GitTestCommand) Exists() bool {
@@ -51,10 +51,10 @@ func NewGitCommand(branch, remoteURL string, tag string, exists bool) GitCommand
 
 func TestSetGitInfo(t *testing.T) {
 	tests := []struct {
-		name    string
 		command GitCommand
-		expect  Git
 		err     error
+		expect  Git
+		name    string
 	}{
 		{
 			name:    "Git https url",
@@ -87,10 +87,10 @@ func TestSetGitInfoWithEnv(t *testing.T) {
 	t.Setenv("GITHUB_HEAD_REF", "feature/branch")
 	t.Setenv("GITHUB_REF", "refs/tags/v1.0.4")
 	tests := []struct {
-		name    string
 		command GitCommand
-		expect  Git
 		err     error
+		expect  Git
+		name    string
 	}{
 		{
 			name:    "Without Git command only with env",
@@ -109,10 +109,10 @@ func TestSetGitInfoWithEnv(t *testing.T) {
 
 func TestSetGitInfoWithError(t *testing.T) {
 	tests := []struct {
-		name    string
 		command GitCommand
-		expect  Git
 		err     error
+		expect  Git
+		name    string
 	}{
 		{
 			name:    "Git https url",
@@ -125,26 +125,26 @@ func TestSetGitInfoWithError(t *testing.T) {
 }
 
 func RunGitInfoTest(t *testing.T, tests []struct {
-	name    string
 	command GitCommand
-	expect  Git
 	err     error
+	expect  Git
+	name    string
 }) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			git = nil
-			git, err := setGitInfo(tt.command)
+			gitInfo, err := setGitInfo(tt.command)
 			if tt.err != nil {
 				assert.ErrorContains(t, err, tt.err.Error())
-				assert.Nil(t, git)
+				assert.Nil(t, gitInfo)
 				return
 			}
 			assert.NoError(t, err)
 
-			assert.Equal(t, tt.expect.Owner, git.Owner)
-			assert.Equal(t, tt.expect.Repo, git.Repo)
-			assert.Equal(t, tt.expect.Branch, git.Branch)
-			assert.Equal(t, tt.expect.Tag, git.Tag)
+			assert.Equal(t, tt.expect.Owner, gitInfo.Owner)
+			assert.Equal(t, tt.expect.Repo, gitInfo.Repo)
+			assert.Equal(t, tt.expect.Branch, gitInfo.Branch)
+			assert.Equal(t, tt.expect.Tag, gitInfo.Tag)
 
 		})
 	}

--- a/pkg/trivy/report.go
+++ b/pkg/trivy/report.go
@@ -26,20 +26,20 @@ type Metadata struct {
 }
 
 type Vulnerability struct {
+	FixedVersion     string   `json:"FixedVersion"`
 	VulnerabilityID  string   `json:"VulnerabilityID"`
-	PrimaryURL       string   `json:"PrimaryURL"`
 	PkgID            string   `json:"PkgID"`
 	PkgPath          string   `json:"PkgPath"`
 	PkgName          string   `json:"PkgName"`
 	InstalledVersion string   `json:"InstalledVersion"`
-	FixedVersion     string   `json:"FixedVersion"`
+	PrimaryURL       string   `json:"PrimaryURL"`
 	Status           string   `json:"Status"`
-	Severity         string   `json:"Severity"`
-	Title            string   `json:"Title"`
 	Description      string   `json:"Description"`
-	References       []string `json:"References"`
-	PublishedDate    string   `json:"PublishedDate"`
+	Title            string   `json:"Title"`
+	Severity         string   `json:"Severity"`
 	LastModifiedDate string   `json:"LastModifiedDate"`
+	PublishedDate    string   `json:"PublishedDate"`
+	References       []string `json:"References"`
 }
 
 type Result struct {
@@ -50,12 +50,12 @@ type Result struct {
 }
 
 type Comment struct {
-	SchemaVersion int       `json:"SchemaVersion"`
 	CreatedAt     time.Time `json:"CreatedAt"`
 	ArtifactName  string    `json:"ArtifactName"`
 	ArtifactType  string    `json:"ArtifactType"`
 	Metadata      Metadata  `json:"Metadata"`
 	Results       []Result  `json:"Results"`
+	SchemaVersion int       `json:"SchemaVersion"`
 }
 
 func Parse(jsonData string) string {

--- a/pkg/trivy/trivy.go
+++ b/pkg/trivy/trivy.go
@@ -75,8 +75,7 @@ func (c *TrivyContainer) CopyScript() error {
 
 	script := fmt.Sprintf(`#!/bin/sh
 set -xe
-trivy image --podman-host /var/run/podman.sock --severity CRITICAL,HIGH --ignore-unfixed -d --scanners vuln --format json --output /usr/src/trivy.json %s
-#chmod 0755 -R /root/.cache/trivy
+trivy image --podman-host /var/run/podman.sock --severity CRITICAL,HIGH --ignore-unfixed -d --scanners vuln --format json --output /usr/src/trivy.json %s || true
 `, image)
 	err := c.Container.CopyContentTo(script, "/tmp/script.sh")
 	if err != nil {


### PR DESCRIPTION
Add support for organizing builds into distinct groups to streamline processing and execute builds efficiently. Update dependencies and make necessary adjustments to accommodate grouped builds.

- Refactor to use build groups
- Update dependencies to version 0.7.0