### PR TITLE
feat(golang): add support for go coverage binary

### DIFF
--- a/pkg/golang/alpine/golang.go
+++ b/pkg/golang/alpine/golang.go
@@ -311,7 +311,8 @@ func (c *GoContainer) Build() error {
 func (c *GoContainer) BuildScript() string {
 	// Create a temporary script in-memory
 	nocoverage := c.GetBuild().Custom.Bool("nocoverage")
-	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, nocoverage, c.Platforms...).String()
+	coverageMode := buildscript.CoverageMode(c.GetBuild().Custom.String("coverage_mode"))
+	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, nocoverage, coverageMode, c.Platforms...).String()
 }
 
 func NewProd(build container.Build) build.Build {

--- a/pkg/golang/debian/golang.go
+++ b/pkg/golang/debian/golang.go
@@ -192,7 +192,8 @@ func (c *GoContainer) Build() error {
 func (c *GoContainer) BuildScript() string {
 	// Create a temporary script in-memory
 	nocoverage := c.GetBuild().Custom.Bool("nocoverage")
-	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, nocoverage, c.Platforms...).String()
+	coverageMode := buildscript.CoverageMode(c.GetBuild().Custom.String("coverage_mode"))
+	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, nocoverage, coverageMode, c.Platforms...).String()
 }
 
 func NewProd(build container.Build) build.Build {

--- a/pkg/golang/debiancgo/golang.go
+++ b/pkg/golang/debiancgo/golang.go
@@ -196,7 +196,8 @@ func (c *GoContainer) BuildScript() string {
 		platforms = types.ParsePlatforms(c.GetBuild().Custom.Strings("platforms")...)
 	}
 	nocoverage := c.GetBuild().Custom.Bool("nocoverage")
-	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, nocoverage, platforms...).String()
+	coverageMode := buildscript.CoverageMode(c.GetBuild().Custom.String("coverage_mode"))
+	return buildscript.NewBuildScript(c.App, c.File, c.Folder, c.Tags, c.Container.Verbose, nocoverage, coverageMode, platforms...).String()
 }
 
 func NewProd(build container.Build) build.Build {


### PR DESCRIPTION
The default mode is still text but to support merging of multiple coverage profiles its better to use binary mode.

```go
package main

import (
	"os"

	"github.com/containifyci/engine-ci/client/pkg/build"
)

func main() {
	_ = os.Chdir("../")
    opts := build.NewGoServiceBuild("go-example")
    opts.Properties = map[string]*build.ListValue{
        // Default mode is text -> coverage.out file will be generated
        // mode binary -> .coverdata/unit directory with the binary
        // coverage data will be generated
        "coverage_mode": build.NewList("binary"),
    }
	build.Serve(opts)
}
```