### PR TITLE
fix(go): ensure coverage directory exists

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -42,7 +42,7 @@ func main() {
 	opts1 := build.NewGoServiceBuild("engine-ci")
 	opts1.File = "main.go"
 	opts1.Properties = map[string]*build.ListValue{
-		"tags": build.NewList("containers_image_openpgp"),
+		"tags":       build.NewList("containers_image_openpgp"),
 		"goreleaser": build.NewList("true"),
 	}
 
@@ -51,8 +51,8 @@ func main() {
 	opts2 := build.NewGoServiceBuild("engine-ci-debian")
 	opts2.File = "main.go"
 	opts2.Properties = map[string]*build.ListValue{
-		"tags":       build.NewList("containers_image_openpgp"),
-		"from":       build.NewList("debian"),
+		"tags": build.NewList("containers_image_openpgp"),
+		"from": build.NewList("debian"),
 	}
 	opts2.Registries = registryAuth()
 

--- a/pkg/golang/buildscript/buildscript.go
+++ b/pkg/golang/buildscript/buildscript.go
@@ -81,7 +81,7 @@ func renderTestCommand(bs *BuildScript, m map[string]interface{}) string {
 	var cmd string
 	switch bs.CoverageMode {
 	case "binary":
-		cmd = "go test {{- .verbose }} -timeout 120s {{- .tags }} -cover ./... {{- .coverage}} "
+		cmd = "mkdir -p ${PWD}/.coverdata/unit\ngo test {{- .verbose }} -timeout 120s {{- .tags }} -cover ./... {{- .coverage}}"
 	case "text":
 		fallthrough
 	default:

--- a/pkg/golang/buildscript/buildscript_test.go
+++ b/pkg/golang/buildscript/buildscript_test.go
@@ -52,6 +52,7 @@ git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
 cd /src
 env GOOS=darwin GOARCH=arm64 go build -o /src/test-darwin-arm64 /src/main.go
 env GOOS=linux GOARCH=amd64 go build -o /src/test-linux-amd64 /src/main.go
+mkdir -p ${PWD}/.coverdata/unit
 go test -timeout 120s -cover ./... -args -test.gocoverdir=${PWD}/.coverdata/unit
 `
 	script := bs.String()


### PR DESCRIPTION
When running go test with `"coverage_mode": build.NewList("binary")` the output is saved in .coverdata/unit. However, the directory must exist beforehand; otherwise, the coverage data cannot be written. This fix ensures the required directory is created before running the tests.