### PR TITLE
chore(go): remove ssh+git setup fo golangci-lint

### DIFF
--- a/pkg/golang/alpine/golangcilint.go
+++ b/pkg/golang/alpine/golangcilint.go
@@ -100,7 +100,6 @@ func (c GolangCiLint) LintScript(tags []string) string {
 set -x
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts
-git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
 %s`, cmd)
 	return script
 }

--- a/pkg/golang/alpine/golangcilint_test.go
+++ b/pkg/golang/alpine/golangcilint_test.go
@@ -14,7 +14,6 @@ func TestCopyLintScript(t *testing.T) {
 set -x
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts
-git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
 golangci-lint --out-format colored-line-number -v run --build-tags build_tag --timeout=5m`, script)
 }
 
@@ -37,7 +36,6 @@ func TestCopyLintScriptGCL(t *testing.T) {
 set -x
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts
-git config --global url."ssh://git@github.com/.insteadOf" "https://github.com/"
 golangci-lint custom
 build/custom-gcl run --build-tags build_tag`, script)
 }


### PR DESCRIPTION
This commit removes the ssh+git setup for golangci-lint. This is because the setup is not needed and it is causing `golangci-lint custom` to fail. If there is no ssh private key setup.