### PR TITLE
fix(goreleaser): correct typo in image tag

### DIFF
--- a/pkg/goreleaser/goreleaser.go
+++ b/pkg/goreleaser/goreleaser.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	IMAGE = "goreleaser/goreleaser:nigthly"
+	IMAGE = "goreleaser/goreleaser:nightly"
 )
 
 type GoReleaserContainer struct {


### PR DESCRIPTION
Correct the misspelling of "nightly" in the IMAGE constant.

- Fix typo from "nigthly" to "nightly"