### PR TITLE
fix(grpc): return errors in GetBuild and GetBuilds

### DIFF
--- a/protos2/grpc.go
+++ b/protos2/grpc.go
@@ -66,15 +66,15 @@ type GRPCServerContainifyCIv1 struct {
 }
 
 func (m *GRPCServerContainifyCIv1) GetBuild(ctx context.Context, _ *Empty) (*BuildArgsResponse, error) {
-	return m.Impl.GetBuild(), nil
+	return m.Impl.GetBuild()
 }
 
-func (m *ContainifyCIv1GRPCClient) GetBuild() *BuildArgsResponse {
+func (m *ContainifyCIv1GRPCClient) GetBuild() (*BuildArgsResponse, error) {
 	args, err := m.client.GetBuild(context.Background(), &Empty{})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return args
+	return args, nil
 }
 
 type GRPCServerContainifyCIv2 struct {
@@ -87,13 +87,13 @@ type GRPCServerContainifyCIv2 struct {
 }
 
 func (m *GRPCServerContainifyCIv2) GetBuilds(ctx context.Context, _ *Empty) (*BuildArgsGroupResponse, error) {
-	return m.Impl.GetBuilds(), nil
+	return m.Impl.GetBuilds()
 }
 
-func (m *ContainifyCIv2GRPCClient) GetBuilds() *BuildArgsGroupResponse {
+func (m *ContainifyCIv2GRPCClient) GetBuilds() (*BuildArgsGroupResponse, error) {
 	args, err := m.client.GetBuilds(context.Background(), &Empty{})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return args
+	return args, nil
 }

--- a/protos2/interface.go
+++ b/protos2/interface.go
@@ -31,11 +31,11 @@ var PluginMap = map[int]plugin.PluginSet{
 }
 
 type ContainifyCIv2 interface {
-	GetBuilds() *BuildArgsGroupResponse
+	GetBuilds() (*BuildArgsGroupResponse, error)
 }
 
 type ContainifyCIv1 interface {
-	GetBuild() *BuildArgsResponse
+	GetBuild() (*BuildArgsResponse, error)
 }
 
 var _ plugin.GRPCPlugin = &ContainifyCIv2GRPCPlugin{}


### PR DESCRIPTION
Both GetBuild and GetBuilds now return an error alongside the response, enhancing error handling capabilities across the application.

- Modify GetBuild method to return error
- Modify GetBuilds method to return error
- Update interface definitions to reflect changes