### PR TITLE
fix(cache): restore GOMODCACHE usage in golang container builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,21 @@ go test ./...
 go run --tags containers_image_openpgp main.go run -t all
 ```
 
+### Performance Optimization for Long-Running Commands
+**TIP**: For long-running commands (builds, tests, analysis), store output in log files for faster analysis:
+
+```bash
+# Store command output in log file for analysis (10 minute timeout)
+timeout 600s go run --tags containers_image_openpgp main.go run -t build --verbose > build.log 2>&1
+
+# Then analyze the log file
+grep -E "(error|cache|volume)" build.log
+grep -A10 -B5 "specific pattern" build.log
+tail -20 build.log  # Check how command ended
+```
+
+This approach is significantly faster than trying to filter output in real-time and allows for multiple analysis passes on the same data.
+
 **Development Philosophy**: 
 - **Keep changes small** and iterate fast
 - **Check build/lint/test** after each logical change

--- a/pkg/golang/alpine/golang.go
+++ b/pkg/golang/alpine/golang.go
@@ -2,7 +2,6 @@ package alpine
 
 import (
 	"context"
-	"crypto/sha256"
 	"embed"
 	"fmt"
 	"log/slog"
@@ -66,8 +65,8 @@ func New(build container.Build) *GoContainer {
 		platforms = []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")}
 	}
 
-	// Create Go Alpine strategy locally to avoid import cycles
-	strategy := newGoAlpineStrategy(build, f, platforms)
+	// Use shared Go Alpine strategy from language package
+	strategy := language.NewAlpineStrategy(build, f, platforms)
 
 	// Create orchestrator with strategy and base builder
 	orchestrator := language.NewContainerBuildOrchestrator(strategy, baseBuilder)
@@ -84,105 +83,6 @@ func New(build container.Build) *GoContainer {
 	}
 }
 
-// goAlpineStrategy implements the LanguageStrategy interface for Go Alpine builds
-type goAlpineStrategy struct {
-	embedFS   embed.FS
-	platforms []*types.PlatformSpec
-	build     container.Build
-}
-
-// newGoAlpineStrategy creates a local Go Alpine strategy to avoid import cycles
-func newGoAlpineStrategy(build container.Build, embedFS embed.FS, platforms []*types.PlatformSpec) language.LanguageStrategy {
-	return &goAlpineStrategy{
-		build:     build,
-		embedFS:   embedFS,
-		platforms: platforms,
-	}
-}
-
-// GetIntermediateImage returns the Go-specific intermediate container image and ensures it's built
-func (s *goAlpineStrategy) GetIntermediateImage(ctx context.Context) (string, error) {
-	dockerFile, err := s.embedFS.ReadFile("Dockerfilego")
-	if err != nil {
-		return "", language.NewBuildError("read_dockerfile", "golang", err)
-	}
-
-	// Compute deterministic tag from dockerfile content (same logic as BaseLanguageBuilder.ComputeImageTag)
-	hash := sha256.Sum256(dockerFile)
-	tag := fmt.Sprintf("%x", hash[:8])
-	image := fmt.Sprintf("golang-%s-alpine", DEFAULT_GO)
-	imageURI := utils.ImageURI(s.build.ContainifyRegistry, image, tag)
-
-	// The orchestrator will handle building the intermediate image using
-	// GetIntermediateImageDockerfile() and GetIntermediateImagePlatforms()
-	return imageURI, nil
-}
-
-// GenerateBuildScript returns the Go-specific build script
-func (s *goAlpineStrategy) GenerateBuildScript() string {
-	// Extract build configuration
-	nocoverage := s.build.Custom.Bool("nocoverage")
-	coverageMode := buildscript.CoverageMode(s.build.Custom.String("coverage_mode"))
-	tags := s.build.Custom["tags"]
-
-	// Adjust file path for container volume mounting
-	// When a specific folder is mounted, the file path should be relative to that folder
-	adjustedFile := s.build.File
-	if s.build.Folder != "" {
-		// Handle both /src/folder/file.go and folder/file.go patterns
-		expectedPath := "/src/" + s.build.Folder + "/"
-		if strings.HasPrefix(s.build.File, expectedPath) {
-			// Remove the /src/folder/ prefix since the folder is mounted as root
-			adjustedFile = strings.TrimPrefix(s.build.File, expectedPath)
-		} else if strings.HasPrefix(s.build.File, s.build.Folder+"/") {
-			// Handle folder/file.go pattern (without /src/ prefix)
-			adjustedFile = strings.TrimPrefix(s.build.File, s.build.Folder+"/")
-		}
-	}
-
-	return buildscript.NewBuildScript(
-		s.build.App,
-		adjustedFile,
-		s.build.Folder,
-		tags,
-		s.build.Verbose,
-		nocoverage,
-		coverageMode,
-		s.platforms...,
-	).String()
-}
-
-// GetAdditionalImages returns additional images needed for Go Alpine builds
-func (s *goAlpineStrategy) GetAdditionalImages() []string {
-	return []string{"alpine:latest"}
-}
-
-// ShouldCommitResult determines if the build result should be committed
-func (s *goAlpineStrategy) ShouldCommitResult() bool {
-	return true // Go builds need to commit results to create optimized final images
-}
-
-// GetCommitCommand returns the commit command for Go Alpine builds
-func (s *goAlpineStrategy) GetCommitCommand() string {
-	return fmt.Sprintf(`CMD ["/app/%s"]`, s.build.App)
-}
-
-// GetIntermediateImageDockerfile returns the dockerfile content for building the intermediate image
-func (s *goAlpineStrategy) GetIntermediateImageDockerfile(ctx context.Context) ([]byte, error) {
-	return s.embedFS.ReadFile("Dockerfilego")
-}
-
-// GetIntermediateImagePlatforms returns the platforms for the intermediate image build
-func (s *goAlpineStrategy) GetIntermediateImagePlatforms() []*types.PlatformSpec {
-	// Convert platform specs to container-compatible platforms (darwin -> linux conversion)
-	var containerPlatforms []*types.PlatformSpec
-	for _, platform := range s.platforms {
-		// Use the same conversion logic as the original code
-		containerPlatform := types.GetImagePlatform(platform)
-		containerPlatforms = append(containerPlatforms, containerPlatform)
-	}
-	return containerPlatforms
-}
 
 // IsAsync returns whether this container runs asynchronously
 func (c *GoContainer) IsAsync() bool {

--- a/pkg/golang/debian/golang.go
+++ b/pkg/golang/debian/golang.go
@@ -2,7 +2,6 @@ package debian
 
 import (
 	"context"
-	"crypto/sha256"
 	"embed"
 	"fmt"
 	"log/slog"
@@ -63,8 +62,8 @@ func New(build container.Build) *GoContainer {
 		platforms = []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")}
 	}
 
-	// Create Go Debian strategy locally to avoid import cycles
-	strategy := newGoDebianStrategy(build, f, platforms)
+	// Use shared Go Debian strategy from language package
+	strategy := language.NewDebianStrategy(build, f, platforms)
 
 	// Create orchestrator with strategy and base builder
 	orchestrator := language.NewContainerBuildOrchestrator(strategy, baseBuilder)
@@ -81,101 +80,6 @@ func New(build container.Build) *GoContainer {
 	}
 }
 
-// goDebianStrategy implements the LanguageStrategy interface for Go Debian builds
-type goDebianStrategy struct {
-	embedFS   embed.FS
-	platforms []*types.PlatformSpec
-	build     container.Build
-}
-
-// newGoDebianStrategy creates a local Go Debian strategy to avoid import cycles
-func newGoDebianStrategy(build container.Build, embedFS embed.FS, platforms []*types.PlatformSpec) language.LanguageStrategy {
-	return &goDebianStrategy{
-		build:     build,
-		embedFS:   embedFS,
-		platforms: platforms,
-	}
-}
-
-// GetIntermediateImage returns the Go-specific intermediate container image (equivalent to GoImage())
-func (s *goDebianStrategy) GetIntermediateImage(ctx context.Context) (string, error) {
-	dockerFile, err := s.embedFS.ReadFile("Dockerfilego")
-	if err != nil {
-		return "", language.NewBuildError("read_dockerfile", "golang", err)
-	}
-
-	// Compute deterministic tag from dockerfile content (same logic as BaseLanguageBuilder.ComputeImageTag)
-	hash := sha256.Sum256(dockerFile)
-	tag := fmt.Sprintf("%x", hash[:8])
-	image := fmt.Sprintf("golang-%s", DEFAULT_GO)
-	return utils.ImageURI(s.build.ContainifyRegistry, image, tag), nil
-}
-
-// GenerateBuildScript returns the Go-specific build script
-func (s *goDebianStrategy) GenerateBuildScript() string {
-	// Extract build configuration
-	nocoverage := s.build.Custom.Bool("nocoverage")
-	coverageMode := buildscript.CoverageMode(s.build.Custom.String("coverage_mode"))
-	tags := s.build.Custom["tags"]
-
-	// Adjust file path for container volume mounting
-	// When a specific folder is mounted, the file path should be relative to that folder
-	adjustedFile := s.build.File
-	if s.build.Folder != "" {
-		// Handle both /src/folder/file.go and folder/file.go patterns
-		expectedPath := "/src/" + s.build.Folder + "/"
-		if strings.HasPrefix(s.build.File, expectedPath) {
-			// Remove the /src/folder/ prefix since the folder is mounted as root
-			adjustedFile = strings.TrimPrefix(s.build.File, expectedPath)
-		} else if strings.HasPrefix(s.build.File, s.build.Folder+"/") {
-			// Handle folder/file.go pattern (without /src/ prefix)
-			adjustedFile = strings.TrimPrefix(s.build.File, s.build.Folder+"/")
-		}
-	}
-
-	return buildscript.NewBuildScript(
-		s.build.App,
-		adjustedFile,
-		s.build.Folder,
-		tags,
-		s.build.Verbose,
-		nocoverage,
-		coverageMode,
-		s.platforms...,
-	).String()
-}
-
-// GetAdditionalImages returns additional images needed for Go Debian builds
-func (s *goDebianStrategy) GetAdditionalImages() []string {
-	return []string{"alpine:latest"}
-}
-
-// ShouldCommitResult determines if the build result should be committed
-func (s *goDebianStrategy) ShouldCommitResult() bool {
-	return true // Go builds need to commit results to create optimized final images
-}
-
-// GetCommitCommand returns the commit command for Go Debian builds
-func (s *goDebianStrategy) GetCommitCommand() string {
-	return fmt.Sprintf(`CMD ["/app/%s"]`, s.build.App)
-}
-
-// GetIntermediateImageDockerfile returns the dockerfile content for building the intermediate image
-func (s *goDebianStrategy) GetIntermediateImageDockerfile(ctx context.Context) ([]byte, error) {
-	return s.embedFS.ReadFile("Dockerfilego")
-}
-
-// GetIntermediateImagePlatforms returns the platforms for the intermediate image build
-func (s *goDebianStrategy) GetIntermediateImagePlatforms() []*types.PlatformSpec {
-	// Convert platform specs to container-compatible platforms (darwin -> linux conversion)
-	var containerPlatforms []*types.PlatformSpec
-	for _, platform := range s.platforms {
-		// Use the same conversion logic as the original code
-		containerPlatform := types.GetImagePlatform(platform)
-		containerPlatforms = append(containerPlatforms, containerPlatform)
-	}
-	return containerPlatforms
-}
 
 // IsAsync returns whether this container runs asynchronously
 func (c *GoContainer) IsAsync() bool {

--- a/pkg/language/golang_strategies.go
+++ b/pkg/language/golang_strategies.go
@@ -1,0 +1,179 @@
+package language
+
+import (
+	"context"
+	"crypto/sha256"
+	"embed"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/containifyci/engine-ci/pkg/container"
+	"github.com/containifyci/engine-ci/pkg/cri/types"
+	"github.com/containifyci/engine-ci/pkg/cri/utils"
+	"github.com/containifyci/engine-ci/pkg/golang/buildscript"
+)
+
+const (
+	DEFAULT_GO = "1.24.2"
+)
+
+// GolangStrategyConfig defines the configuration for different golang strategies
+type GolangStrategyConfig struct {
+	ImageSuffix  string // e.g., "-alpine", "", "-cgo"
+	DockerFile   string // e.g., "Dockerfilego"
+	GoVersion    string // e.g., "1.24.2"
+}
+
+// golangStrategy provides a unified implementation for all golang language strategies
+// This eliminates ~100 lines of duplicated code per golang package
+type golangStrategy struct {
+	config    GolangStrategyConfig
+	embedFS   embed.FS
+	platforms []*types.PlatformSpec
+	build     container.Build
+}
+
+// NewAlpineStrategy creates a golang strategy for Alpine builds
+func NewAlpineStrategy(build container.Build, embedFS embed.FS, platforms []*types.PlatformSpec) LanguageStrategy {
+	return &golangStrategy{
+		config: GolangStrategyConfig{
+			ImageSuffix: "-alpine",
+			DockerFile:  "Dockerfilego",
+			GoVersion:   DEFAULT_GO,
+		},
+		build:     build,
+		embedFS:   embedFS,
+		platforms: platforms,
+	}
+}
+
+// NewDebianStrategy creates a golang strategy for Debian builds
+func NewDebianStrategy(build container.Build, embedFS embed.FS, platforms []*types.PlatformSpec) LanguageStrategy {
+	return &golangStrategy{
+		config: GolangStrategyConfig{
+			ImageSuffix: "",
+			DockerFile:  "Dockerfilego",
+			GoVersion:   DEFAULT_GO,
+		},
+		build:     build,
+		embedFS:   embedFS,
+		platforms: platforms,
+	}
+}
+
+// NewDebianCGOStrategy creates a golang strategy for Debian CGO builds
+func NewDebianCGOStrategy(build container.Build, embedFS embed.FS, platforms []*types.PlatformSpec) LanguageStrategy {
+	return &golangStrategy{
+		config: GolangStrategyConfig{
+			ImageSuffix: "-cgo",
+			DockerFile:  "Dockerfilego",
+			GoVersion:   DEFAULT_GO,
+		},
+		build:     build,
+		embedFS:   embedFS,
+		platforms: platforms,
+	}
+}
+
+// GetIntermediateImage returns the Go-specific intermediate container image
+// Unified implementation for all golang variants with configurable image naming
+func (s *golangStrategy) GetIntermediateImage(ctx context.Context) (string, error) {
+	dockerFile, err := s.embedFS.ReadFile(s.config.DockerFile)
+	if err != nil {
+		return "", NewBuildError("read_dockerfile", "golang", err)
+	}
+
+	// Compute deterministic tag from dockerfile content
+	hash := sha256.Sum256(dockerFile)
+	tag := fmt.Sprintf("%x", hash[:8])
+	image := fmt.Sprintf("golang-%s%s", s.config.GoVersion, s.config.ImageSuffix)
+	return utils.ImageURI(s.build.ContainifyRegistry, image, tag), nil
+}
+
+// GenerateBuildScript returns the Go-specific build script
+// Unified implementation with common file path adjustment logic
+func (s *golangStrategy) GenerateBuildScript() string {
+	// Extract build configuration
+	nocoverage := s.build.Custom.Bool("nocoverage")
+	coverageMode := buildscript.CoverageMode(s.build.Custom.String("coverage_mode"))
+	tags := s.build.Custom["tags"]
+
+	// Adjust file path for container volume mounting
+	// When a specific folder is mounted, the file path should be relative to that folder
+	adjustedFile := s.build.File
+	if s.build.Folder != "" {
+		// Handle both /src/folder/file.go and folder/file.go patterns
+		expectedPath := "/src/" + s.build.Folder + "/"
+		if strings.HasPrefix(s.build.File, expectedPath) {
+			// Remove the /src/folder/ prefix since the folder is mounted as root
+			adjustedFile = strings.TrimPrefix(s.build.File, expectedPath)
+		} else if strings.HasPrefix(s.build.File, s.build.Folder+"/") {
+			// Handle folder/file.go pattern (without /src/ prefix)
+			adjustedFile = strings.TrimPrefix(s.build.File, s.build.Folder+"/")
+		}
+	}
+
+	return buildscript.NewBuildScript(
+		s.build.App,
+		adjustedFile,
+		s.build.Folder,
+		tags,
+		s.build.Verbose,
+		nocoverage,
+		coverageMode,
+		s.platforms...,
+	).String()
+}
+
+// GetAdditionalImages returns additional images needed for Go builds
+// All golang variants use the same additional images
+func (s *golangStrategy) GetAdditionalImages() []string {
+	return []string{"alpine:latest"}
+}
+
+// ShouldCommitResult determines if the build result should be committed
+// All golang variants need to commit results to create optimized final images
+func (s *golangStrategy) ShouldCommitResult() bool {
+	return true
+}
+
+// GetCommitCommand returns the commit command for Go builds
+// Unified implementation across all golang variants
+func (s *golangStrategy) GetCommitCommand() string {
+	return fmt.Sprintf(`CMD ["/app/%s"]`, s.build.App)
+}
+
+// GetIntermediateImageDockerfile returns the dockerfile content for building the intermediate image
+// Unified implementation using configurable dockerfile name
+func (s *golangStrategy) GetIntermediateImageDockerfile(ctx context.Context) ([]byte, error) {
+	return s.embedFS.ReadFile(s.config.DockerFile)
+}
+
+// GetIntermediateImagePlatforms returns the platforms for the intermediate image build
+// Unified platform conversion logic for all golang variants
+func (s *golangStrategy) GetIntermediateImagePlatforms() []*types.PlatformSpec {
+	// Convert platform specs to container-compatible platforms (darwin -> linux conversion)
+	var containerPlatforms []*types.PlatformSpec
+	for _, platform := range s.platforms {
+		// Use the same conversion logic as the original code
+		containerPlatform := types.GetImagePlatform(platform)
+		containerPlatforms = append(containerPlatforms, containerPlatform)
+	}
+	return containerPlatforms
+}
+
+// GetCacheDirectory returns the Go module cache directory using 'go env GOMODCACHE'
+// Unified cache resolution for all golang variants (alpine, debian, debiancgo)
+func (s *golangStrategy) GetCacheDirectory() (string, error) {
+	// Execute 'go env GOMODCACHE' to get the proper Go module cache location
+	cmd := exec.Command("go", "env", "GOMODCACHE")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", NewCacheError("get_gomodcache", "golang", err)
+	}
+
+	// Clean and return the cache directory path
+	gomodcache := strings.TrimSpace(string(output))
+	return gomodcache, nil
+}


### PR DESCRIPTION
- Add GetCacheDirectory() method to LanguageStrategy interface
- Implement language-specific cache resolution in golang strategies
- Update ContainerBuildOrchestrator to use strategy cache resolution
- Fix regression where builds used .tmp/golang-alpine instead of GOMODCACHE
- Maintain backward compatibility with fallback to .tmp/go pattern
- Add performance optimization tip to CLAUDE.md for log analysis

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
