### PR TITLE
feat(build): Simplify build step interface and logic

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -44,9 +44,6 @@ func main() {
 		"goreleaser": build.NewList("true"),
 	}
 	opts1.Image = ""
-	opts1.ContainerFiles = map[string]*protos2.ContainerFile{
-		"build": DockerFile(),
-	}
 
 	custom := build.NewGoServiceBuild("engine-ci-custom")
 	custom.File = "main.go"

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -129,9 +129,9 @@ func Pre(arg *container.Build, bs *build.BuildSteps) (*container.Build, *build.B
 		slog.Info("Registering all build steps by category", "build", *a)
 
 		// Helper function to add step and log error
-		addStep := func(category build.BuildCategory, step build.BuildStep, async bool) {
+		addStep := func(category build.BuildCategory, step build.BuildStepv2) {
 			var err error
-			if async {
+			if step.IsAsync() {
 				err = bs.AddAsyncToCategory(category, step)
 			} else {
 				err = bs.AddToCategory(category, step)
@@ -142,35 +142,35 @@ func Pre(arg *container.Build, bs *build.BuildSteps) (*container.Build, *build.B
 		}
 
 		// Auth: Authentication & credentials
-		addStep(build.Auth, gcloud.New(*a), false)
+		addStep(build.Auth, gcloud.New())
 
 		// PreBuild: Setup, protobuf, dependencies
-		addStep(build.PreBuild, protobuf.New(*a), false)
+		addStep(build.PreBuild, protobuf.New())
 
 		// Build: Language-specific compilation
-		addStep(build.Build, golang.New(*a), false)       // Alpine variant
-		addStep(build.Build, golang.NewDebian(*a), false) // Debian variant
-		addStep(build.Build, golang.NewCGO(*a), false)    // CGO variant
-		addStep(build.Build, maven.New(*a), false)        // Maven
-		addStep(build.Build, python.New(*a), false)       // Python
+		addStep(build.Build, golang.New())       // Alpine variant
+		addStep(build.Build, golang.NewDebian()) // Debian variant
+		addStep(build.Build, golang.NewCGO())    // CGO variant
+		addStep(build.Build, maven.New())        // Maven
+		addStep(build.Build, python.New())       // Python
 
 		// PostBuild: Production artifacts, packaging
-		addStep(build.PostBuild, golang.NewProd(*a), false)       // Alpine prod
-		addStep(build.PostBuild, golang.NewProdDebian(*a), false) // Debian prod
-		addStep(build.PostBuild, maven.NewProd(*a), false)        // Maven prod
-		addStep(build.PostBuild, python.NewProd(*a), false)       // Python prod
+		addStep(build.PostBuild, golang.NewProd())       // Alpine prod
+		addStep(build.PostBuild, golang.NewProdDebian()) // Debian prod
+		addStep(build.PostBuild, maven.NewProd())        // Maven prod
+		addStep(build.PostBuild, python.NewProd())       // Python prod
 
 		// Quality: Linting, testing, security scanning
-		addStep(build.Quality, golang.NewLinter(*a), true) // Golang linter (async)
-		addStep(build.Quality, sonarcloud.New(*a), true)   // SonarCloud (async)
-		addStep(build.Quality, trivy.New(*a), false)       // Trivy
+		addStep(build.Quality, golang.NewLinter()) // Golang linter (async)
+		addStep(build.Quality, sonarcloud.New())   // SonarCloud (async)
+		addStep(build.Quality, trivy.New())        // Trivy
 
 		// Apply: Infrastructure changes
-		addStep(build.Apply, pulumi.New(*a), false) // Pulumi
+		addStep(build.Apply, pulumi.New()) // Pulumi
 
 		// Publish: Publishing, releases, notifications
-		addStep(build.Publish, goreleaser.New(*a), false) // Goreleaser
-		addStep(build.Publish, github.New(*a), true)      // GitHub (async)
+		addStep(build.Publish, goreleaser.New()) // Goreleaser
+		addStep(build.Publish, github.New())     // GitHub (async)
 
 		bs.Init()
 	}

--- a/pkg/build/wrapper.go
+++ b/pkg/build/wrapper.go
@@ -1,0 +1,48 @@
+package build
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/containifyci/engine-ci/pkg/container"
+)
+
+type Stepper struct {
+	RunFn     RunFuncv2
+	MatchedFn func(build container.Build) bool
+	ImagesFn  func(build container.Build) []string
+	Name_     string
+	Async_    bool
+}
+
+func (g Stepper) Run() error {
+	fmt.Printf("deprected Run call without build %v\n", g)
+	os.Exit(1)
+	return nil
+}
+func (g Stepper) RunWithBuild(build container.Build) error { return g.RunFn(build) }
+func (g Stepper) Name() string                             { return g.Name_ }
+
+func (g Stepper) Images(build container.Build) []string {
+	if g.ImagesFn != nil {
+		return g.ImagesFn(build)
+	}
+	return []string{}
+}
+func (g Stepper) IsAsync() bool { return g.Async_ }
+
+// Matches implements the Build interface provider matching logic
+func (g Stepper) Matches(build container.Build) bool {
+	if g.MatchedFn != nil {
+		return g.MatchedFn(build)
+	}
+	return false
+}
+
+func StepperImages(images ...string) func(build container.Build) []string {
+	return func(build container.Build) []string {
+		return images
+	}
+}
+
+var _ BuildStepv2 = (*Stepper)(nil)

--- a/pkg/golang/debiancgo/golang.go
+++ b/pkg/golang/debiancgo/golang.go
@@ -40,7 +40,31 @@ type GoContainer struct {
 	Tags      []string
 }
 
-func New(build container.Build) *GoContainer {
+// Matches implements the Build interface - CGO variant runs when from=debiancgo
+func Matches(build container.Build) bool {
+	if build.BuildType != container.GoLang {
+		return false
+	}
+	if from, ok := build.Custom["from"]; ok && len(from) > 0 {
+		return from[0] == "debiancgo"
+	}
+	return false
+}
+
+func New() build.BuildStepv2 {
+	return build.Stepper{
+		RunFn: func(build container.Build) error {
+			container := new(build)
+			return container.Run()
+		},
+		MatchedFn: Matches,
+		ImagesFn:  Images,
+		Name_:     "golang",
+		Async_:    false,
+	}
+}
+
+func new(build container.Build) *GoContainer {
 	platforms := []*types.PlatformSpec{build.Platform.Container}
 	if !build.Platform.Same() {
 		slog.Debug("Different platform detected", "host", build.Platform.Host, "container", build.Platform.Container)
@@ -59,25 +83,6 @@ func New(build container.Build) *GoContainer {
 		Folder:    build.Folder,
 		Tags:      build.Custom["tags"],
 	}
-}
-
-func (c *GoContainer) IsAsync() bool {
-	return false
-}
-
-func (c *GoContainer) Name() string {
-	return "golang"
-}
-
-// Matches implements the Build interface - CGO variant runs when from=debiancgo
-func (c *GoContainer) Matches(build container.Build) bool {
-	if build.BuildType != container.GoLang {
-		return false
-	}
-	if from, ok := build.Custom["from"]; ok && len(from) > 0 {
-		return from[0] == "debiancgo"
-	}
-	return false
 }
 
 func CacheFolder() string {
@@ -102,30 +107,7 @@ func (c *GoContainer) Pull() error {
 	return c.Container.Pull(imageTag, "alpine:latest")
 }
 
-type GoBuild struct {
-	rf     build.RunFunc
-	name   string
-	images []string
-	async  bool
-}
-
-func (g GoBuild) Run() error       { return g.rf() }
-func (g GoBuild) Name() string     { return g.name }
-func (g GoBuild) Images() []string { return g.images }
-func (g GoBuild) IsAsync() bool    { return g.async }
-
-// Matches implements the Build interface - CGO variant runs when from=debiancgo
-func (g GoBuild) Matches(build container.Build) bool {
-	if build.BuildType != container.GoLang {
-		return false
-	}
-	if from, ok := build.Custom["from"]; ok && len(from) > 0 {
-		return from[0] == "debiancgo"
-	}
-	return false
-}
-
-func (c *GoContainer) GoImage() string {
+func GoImage(build container.Build) string {
 	dockerFile, err := f.ReadFile("Dockerfilego")
 	if err != nil {
 		slog.Error("Failed to read Dockerfile.go", "error", err)
@@ -133,17 +115,17 @@ func (c *GoContainer) GoImage() string {
 	}
 	tag := container.ComputeChecksum(dockerFile)
 	image := fmt.Sprintf("golang-%s-cgo", DEFAULT_GO)
-	return utils.ImageURI(c.GetBuild().ContainifyRegistry, image, tag)
+	return utils.ImageURI(build.ContainifyRegistry, image, tag)
 }
 
-func (c *GoContainer) Images() []string {
+func Images(build container.Build) []string {
 	image := fmt.Sprintf("golang:%s", DEFAULT_GO)
 
-	return []string{image, "alpine:latest", c.GoImage()}
+	return []string{image, "alpine:latest", GoImage(build)}
 }
 
 func (c *GoContainer) BuildGoImage() error {
-	image := c.GoImage()
+	image := GoImage(*c.GetBuild())
 
 	dockerFile, err := f.ReadFile("Dockerfilego")
 	if err != nil {
@@ -157,7 +139,7 @@ func (c *GoContainer) BuildGoImage() error {
 }
 
 func (c *GoContainer) Build() error {
-	imageTag := c.GoImage()
+	imageTag := GoImage(*c.GetBuild())
 
 	ssh, err := network.SSHForward(*c.GetBuild())
 	if err != nil {
@@ -223,14 +205,14 @@ func (c *GoContainer) BuildScript() string {
 	return buildscript.NewBuildScript(c.App, c.File.Container(), c.Folder, c.Tags, c.Container.Verbose, nocoverage, coverageMode, platforms...).String()
 }
 
-func NewProd(build container.Build) build.BuildStep {
-	container := New(build)
-	return GoBuild{
-		rf: func() error {
+func NewProd() build.BuildStepv2 {
+	return build.Stepper{
+		RunFn: func(build container.Build) error {
+			container := new(build)
 			return container.Prod()
 		},
-		name: "golang-prod",
-		// images: []string{"alpine"},
+		MatchedFn: Matches,
+		Name_:     "golang-prod",
 	}
 }
 

--- a/pkg/golang/golang.go
+++ b/pkg/golang/golang.go
@@ -2,32 +2,31 @@ package golang
 
 import (
 	"github.com/containifyci/engine-ci/pkg/build"
-	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/golang/alpine"
 	"github.com/containifyci/engine-ci/pkg/golang/debian"
 	"github.com/containifyci/engine-ci/pkg/golang/debiancgo"
 )
 
-func New(build container.Build) *alpine.GoContainer {
-	return alpine.New(build)
+func New() build.BuildStepv2 {
+	return alpine.New()
 }
 
-func NewDebian(build container.Build) *debian.GoContainer {
-	return debian.New(build)
+func NewDebian() build.BuildStepv2 {
+	return debian.New()
 }
 
-func NewProdDebian(build container.Build) build.BuildStep {
-	return debian.NewProd(build)
+func NewProdDebian() build.BuildStepv2 {
+	return debian.NewProd()
 }
 
-func NewCGO(build container.Build) *debiancgo.GoContainer {
-	return debiancgo.New(build)
+func NewCGO() build.BuildStepv2 {
+	return debiancgo.New()
 }
 
-func NewProd(build container.Build) build.BuildStep {
-	return alpine.NewProd(build)
+func NewProd() build.BuildStepv2 {
+	return alpine.NewProd()
 }
 
-func NewLinter(build container.Build) build.BuildStep {
-	return alpine.NewLinter(build)
+func NewLinter() build.BuildStepv2 {
+	return alpine.NewLinter()
 }

--- a/pkg/pulumi/pulumi.go
+++ b/pkg/pulumi/pulumi.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containifyci/engine-ci/pkg/build"
 	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/cri/types"
 	"github.com/containifyci/engine-ci/pkg/cri/utils"
@@ -27,27 +28,28 @@ type PulumiContainer struct {
 	*container.Container
 }
 
-func New(build container.Build) *PulumiContainer {
-	return &PulumiContainer{
-		Container: container.New(build),
-	}
-}
-
-func (c *PulumiContainer) IsAsync() bool {
-	return false
-}
-
-func (c *PulumiContainer) Name() string {
-	return "pulumi"
-}
-
 // Matches implements the Build interface - Pulumi only runs for golang builds
-func (c *PulumiContainer) Matches(build container.Build) bool {
+func Matches(build container.Build) bool {
 	return build.BuildType == container.GoLang
 }
 
-func (c *PulumiContainer) Images() []string {
-	return []string{IMAGE}
+func New() build.BuildStepv2 {
+	return build.Stepper{
+		RunFn: func(build container.Build) error {
+			container := new(build)
+			return container.Run()
+		},
+		MatchedFn: Matches,
+		ImagesFn:  build.StepperImages(IMAGE),
+		Name_:     "pulumi",
+		Async_:    false,
+	}
+}
+
+func new(build container.Build) *PulumiContainer {
+	return &PulumiContainer{
+		Container: container.New(build),
+	}
 }
 
 func CacheFolder() string {

--- a/pkg/sonarcloud/sonarcloud.go
+++ b/pkg/sonarcloud/sonarcloud.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containifyci/engine-ci/pkg/build"
 	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/cri/types"
 	"github.com/containifyci/engine-ci/pkg/filesystem"
@@ -25,27 +26,28 @@ type SonarcloudContainer struct {
 	*container.Container
 }
 
-func New(build container.Build) *SonarcloudContainer {
-	return &SonarcloudContainer{
-		Container: container.New(build),
-	}
-}
-
-func (c *SonarcloudContainer) IsAsync() bool {
-	return true
-}
-
-func (c *SonarcloudContainer) Name() string {
-	return "sonarcloud"
-}
-
 // Matches implements the Build interface - SonarCloud runs for all builds
-func (c *SonarcloudContainer) Matches(build container.Build) bool {
+func Matches(build container.Build) bool {
 	return true // SonarCloud analysis runs for all builds
 }
 
-func (c *SonarcloudContainer) Images() []string {
-	return []string{IMAGE}
+func New() build.BuildStepv2 {
+	return build.Stepper{
+		RunFn: func(build container.Build) error {
+			container := new(build)
+			return container.Run()
+		},
+		MatchedFn: Matches,
+		ImagesFn:  build.StepperImages(IMAGE),
+		Name_:     "sonarcloud",
+		Async_:    true,
+	}
+}
+
+func new(build container.Build) *SonarcloudContainer {
+	return &SonarcloudContainer{
+		Container: container.New(build),
+	}
 }
 
 func CacheFolder() string {

--- a/pkg/trivy/trivy.go
+++ b/pkg/trivy/trivy.go
@@ -7,6 +7,7 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"github.com/containifyci/engine-ci/pkg/build"
 	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/cri/types"
 	"github.com/containifyci/engine-ci/pkg/cri/utils"
@@ -21,27 +22,28 @@ type TrivyContainer struct {
 	*container.Container
 }
 
-func New(build container.Build) *TrivyContainer {
-	return &TrivyContainer{
-		Container: container.New(build),
-	}
-}
-
-func (c *TrivyContainer) IsAsync() bool {
-	return false
-}
-
-func (c *TrivyContainer) Name() string {
-	return "trivy"
-}
-
 // Matches implements the Build interface - Trivy runs for all builds
-func (c *TrivyContainer) Matches(build container.Build) bool {
+func Matches(build container.Build) bool {
 	return true // Trivy security scanning runs for all builds
 }
 
-func (c *TrivyContainer) Images() []string {
-	return []string{IMAGE}
+func New() build.BuildStepv2 {
+	return build.Stepper{
+		RunFn: func(build container.Build) error {
+			container := new(build)
+			return container.Run()
+		},
+		MatchedFn: Matches,
+		ImagesFn:  build.StepperImages(IMAGE),
+		Name_:     "trivy",
+		Async_:    false,
+	}
+}
+
+func new(build container.Build) *TrivyContainer {
+	return &TrivyContainer{
+		Container: container.New(build),
+	}
 }
 
 func CacheFolder() string {


### PR DESCRIPTION
Refactor the build step interface to use a unified structure for all build steps.

This change includes the introduction of `BuildStepv2` to decuple the build step initialization from its execution logic. This allows to initialize the build steps without the need to pass the parsed build parameters everywhere.

- Replace `BuildStep` with `BuildStepv2` throughout the codebase.
- Update all build steps to implement the new unified interface.
- Improve code readability and maintainability by reducing duplication.