### PR TITLE
chore(workflow): comment out install dependencies

### DIFF
--- a/.github/workflows/engine-ci-workflow.yml
+++ b/.github/workflows/engine-ci-workflow.yml
@@ -150,11 +150,11 @@ jobs:
           chmod: 0755
           # token: ${{ secrets.CONTAINIFYCI_RELEASE_TOKEN }}
 
-      - name: Install libbtrfs-dev needed by podman go module and libgpgme-dev for containers_image_openpgp
-        if: ${{ !inputs.install_binary }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install libbtrfs-dev libgpgme-dev
+      # - name: Install libbtrfs-dev needed by podman go module and libgpgme-dev for containers_image_openpgp
+      #   if: ${{ !inputs.install_binary }}
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install libbtrfs-dev libgpgme-dev
 
       - name: Prepare Github Action
         run: |


### PR DESCRIPTION
Comment out the step that installs `libbtrfs-dev` and `libgpgme-dev` in the CI workflow.

- Comment out dependency installation for CI