### PR TITLE
chore(workflows): comment out dependencies

### DIFF
--- a/.github/workflows/artifact.yaml
+++ b/.github/workflows/artifact.yaml
@@ -44,10 +44,11 @@ jobs:
           tag: ${{ inputs.tag_name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install libbtrfs-dev needed by podman go module
-        run: |
-          sudo apt-get update
-          sudo apt-get install libbtrfs-dev
+      # Looks like this dependencies are not needed anymore stil keep it here for reference
+      # - name: Install libbtrfs-dev needed by podman go module
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install libbtrfs-dev
 
       - name: Install go
         uses: actions/setup-go@v6

--- a/.github/workflows/engine-ci-workflow.yml
+++ b/.github/workflows/engine-ci-workflow.yml
@@ -150,6 +150,7 @@ jobs:
           chmod: 0755
           # token: ${{ secrets.CONTAINIFYCI_RELEASE_TOKEN }}
 
+      # Looks like this dependencies are not needed anymore stil keep it here for reference
       # - name: Install libbtrfs-dev needed by podman go module and libgpgme-dev for containers_image_openpgp
       #   if: ${{ !inputs.install_binary }}
       #   run: |


### PR DESCRIPTION
Comment out the installation steps for `libbtrfs-dev` in the GitHub workflows, as these dependencies are no longer needed. This change retains the commands for reference in case they are required in the future.

- Comment out unused package installation steps
- Keep commands for future reference