### PR TITLE
fix(command): add version sub command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:         "version",
+	Short:       "Show the current version of engine-ci",
+	Long:        `Display the current version information for the engine-ci binary.`,
+	Run:         runVersion,
+	Annotations: map[string]string{skipRootHooks: "true"},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func runVersion(cmd *cobra.Command, _ []string) {
+	b, _ := json.MarshalIndent(RootArgs.version, "", "  ")
+	fmt.Println(string(b))
+}


### PR DESCRIPTION
Add a new command to display the current version of the engine-ci binary in json format.

- Integrate the version sub command with the root command.