### PR TITLE
fix(secret): integrate secret management

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containifyci/engine-ci/pkg/build"
 	"github.com/containifyci/engine-ci/pkg/container"
+	"github.com/containifyci/engine-ci/pkg/copier"
 	"github.com/containifyci/engine-ci/pkg/gcloud"
 	"github.com/containifyci/engine-ci/pkg/github"
 	"github.com/containifyci/engine-ci/pkg/golang"
@@ -144,6 +145,7 @@ func Pre(arg *container.Build, bs *build.BuildSteps) (*container.Build, *build.B
 		addStep(build.Auth, gcloud.New())
 
 		// PreBuild: Setup, protobuf, dependencies
+		addStep(build.PreBuild, copier.New())
 		addStep(build.PreBuild, protobuf.New())
 
 		// Build: Language-specific compilation

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
+	github.com/moby/term v0.5.2
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1
@@ -101,7 +102,6 @@ require (
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
-	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/pkg/container/build.go
+++ b/pkg/container/build.go
@@ -97,26 +97,24 @@ type Build struct {
 	Custom             Custom
 	Registries         map[string]*protos2.ContainerRegistry
 	ContainerFiles     map[string]*protos2.ContainerFile
-	Registry           string
-	File               string
-	App                string `json:"app"`
+	Secret             map[string]string
+	ContainifyRegistry string
+	Runtime            utils.RuntimeType
 	Image              string `json:"image"`
 	ImageTag           string `json:"image_tag"`
-	ContainifyRegistry string
+	File               string
 	Env                EnvType
 	Folder             string
 	Repository         string
 	Organization       string
-	Runtime            utils.RuntimeType
+	App                string    `json:"app"`
 	BuildType          BuildType `json:"build_type"`
-	BuilderFunction    string    // Name of the client build function to use (e.g., "NewGoServiceBuild")
-	SourceFiles        []string
+	BuilderFunction    string
+	Registry           string
 	SourcePackages     []string
+	SourceFiles        []string
 	Verbose            bool
 	defaults           bool
-
-	// Internal fields not exposed via CLI or API
-	Secret map[string]string
 }
 
 type BuildGroup struct {

--- a/pkg/container/build.go
+++ b/pkg/container/build.go
@@ -114,6 +114,9 @@ type Build struct {
 	SourcePackages     []string
 	Verbose            bool
 	defaults           bool
+
+	// Internal fields not exposed via CLI or API
+	Secret map[string]string
 }
 
 type BuildGroup struct {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -80,6 +80,9 @@ type Container struct {
 	ID      string
 	Opts    types.ContainerConfig
 	Verbose bool
+
+	//TODO suppress in log output
+	Secret map[string]string
 }
 
 type PushOption struct {
@@ -108,7 +111,7 @@ func New(build Build) *Container {
 
 	// Use background context with reasonable timeout instead of TODO
 	ctx := context.Background()
-	container := &Container{t: t{client: _client, ctx: ctx}, Env: build.Env, Build: &build, Verbose: build.Verbose}
+	container := &Container{t: t{client: _client, ctx: ctx}, Env: build.Env, Build: &build, Secret: build.Secret, Verbose: build.Verbose}
 
 	return container
 }

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -70,9 +70,9 @@ func (e *EnvType) Type() string {
 
 type Container struct {
 	t
-	Source fs.ReadDirFS
-	Build  *Build
-	// concurrentManager *ConcurrentContainerManager
+	Source  fs.ReadDirFS
+	Build   *Build
+	Secret  map[string]string
 	Env     EnvType
 	Prefix  string
 	Image   string
@@ -80,9 +80,6 @@ type Container struct {
 	ID      string
 	Opts    types.ContainerConfig
 	Verbose bool
-
-	//TODO suppress in log output
-	Secret map[string]string
 }
 
 type PushOption struct {

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -21,8 +21,8 @@ type CopierContainer struct {
 	Build        *container.Build
 	SourceFolder string
 	TargetFolder string
-	TemplateData []string
 	TemplatePath string
+	TemplateData []string
 }
 
 func New() build.BuildStepv2 {

--- a/pkg/copier/copier.go
+++ b/pkg/copier/copier.go
@@ -1,0 +1,180 @@
+package copier
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containifyci/engine-ci/pkg/build"
+	"github.com/containifyci/engine-ci/pkg/container"
+	"github.com/containifyci/engine-ci/pkg/cri/types"
+)
+
+const (
+	COPIER_IMAGE = "webedia/copier:9.1-2025-09-30"
+	COPIER_FILE  = "copier.yml"
+)
+
+type CopierContainer struct {
+	*container.Container
+	Build        *container.Build
+	SourceFolder string
+	TargetFolder string
+	TemplateData []string
+	TemplatePath string
+}
+
+func New() build.BuildStepv2 {
+	return build.Stepper{
+		RunFn: func(build container.Build) error {
+			copierContainer := new(build)
+			return copierContainer.Run()
+		},
+		MatchedFn: Matches,
+		ImagesFn:  CopierImages,
+		Name_:     "copier",
+		Async_:    false,
+	}
+}
+
+func new(build container.Build) *CopierContainer {
+	return &CopierContainer{
+		Container:    container.New(build),
+		Build:        &build,
+		SourceFolder: build.Folder,
+		TargetFolder: extractOutputPath(build),
+		TemplateData: extractTemplateData(build),
+		TemplatePath: extractTemplatePath(build),
+	}
+}
+
+func CopierImages(build container.Build) []string {
+	return []string{COPIER_IMAGE}
+}
+
+func Matches(build container.Build) bool {
+	folder := build.Folder
+	if folder == "" {
+		folder = "./"
+	}
+
+	tmpPath := extractTemplatePath(build)
+	if tmpPath == "" {
+		tmpPath = folder
+	}
+
+	copierFile := filepath.Join(tmpPath, COPIER_FILE)
+	if _, err := os.Stat(copierFile); os.IsNotExist(err) {
+		slog.Debug("No copier.yml file found", "path", copierFile)
+		return false
+	}
+
+	slog.Debug("Found copier.yml file", "path", copierFile)
+	return true
+}
+
+func extractTemplateData(build container.Build) []string {
+	tmpData := []string{}
+
+	// Extract common template parameters from build.Custom
+	if data, ok := build.Custom["data"]; ok && len(data) > 0 {
+		tmpData = append(tmpData, data...)
+	}
+	return tmpData
+}
+
+func extractTemplatePath(build container.Build) string {
+	if templatePath, ok := build.Custom["template_path"]; ok && len(templatePath) > 0 {
+		return templatePath[0]
+	}
+	return ""
+}
+
+func extractOutputPath(build container.Build) string {
+	if outputPath, ok := build.Custom["output_path"]; ok && len(outputPath) > 0 {
+		return outputPath[0]
+	}
+	return ""
+}
+
+func (c *CopierContainer) buildCopierCommand() []string {
+	args := []string{"copier", "copy"}
+
+	// Add data parameters
+	for _, value := range c.TemplateData {
+		args = append(args, "--data", value)
+	}
+
+	// Add defaults if template path is provided
+	if c.TemplatePath != "" {
+		args = append(args, "--defaults", c.TemplatePath)
+	}
+	// Add overwrite flag
+	args = append(args, "--overwrite")
+
+	// Add target directory
+	args = append(args, c.TargetFolder)
+
+	return args
+}
+
+func (c *CopierContainer) Run() error {
+	err := c.Pull()
+	if err != nil {
+		slog.Error("Failed to pull copier image", "error", err)
+		return err
+	}
+
+	return c.Execute()
+}
+
+func (c *CopierContainer) Pull() error {
+	return c.Container.Pull(COPIER_IMAGE)
+}
+
+func (c *CopierContainer) Execute() error {
+	opts := types.ContainerConfig{}
+	opts.Image = COPIER_IMAGE
+	opts.Cmd = c.buildCopierCommand()
+	opts.WorkingDir = "/src"
+
+	// Get absolute path for the folder
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		slog.Error("Failed to get absolute path", "error", err)
+		return err
+	}
+
+	// Mount the source folder as workspace
+	opts.Volumes = []types.Volume{{
+		Type:   "bind",
+		Source: dir,
+		Target: "/src",
+	}}
+
+	if c.Build.Verbose {
+		slog.Info("Executing copier command", "cmd", strings.Join(opts.Cmd, " "), "volumes", opts.Volumes)
+	}
+
+	err = c.Create(opts)
+	if err != nil {
+		slog.Error("Failed to create copier container", "error", err)
+		return err
+	}
+
+	err = c.Start()
+	if err != nil {
+		slog.Error("Failed to start copier container", "error", err)
+		return err
+	}
+
+	err = c.Wait()
+	if err != nil {
+		slog.Error("Copier execution failed", "error", err)
+		return err
+	}
+
+	slog.Info("Copier execution completed successfully")
+	return nil
+}

--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -1,0 +1,344 @@
+package copier
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/containifyci/engine-ci/pkg/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	step := New()
+	assert.NotNil(t, step)
+	assert.Equal(t, "copier", step.Name())
+	assert.False(t, step.IsAsync())
+}
+
+func TestCopierImages(t *testing.T) {
+	build := container.Build{}
+	images := CopierImages(build)
+
+	expected := []string{COPIER_IMAGE}
+	assert.Equal(t, expected, images)
+}
+
+func TestMatches_WithCopierFile(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	// Create a copier.yml file
+	copierFile := filepath.Join(tempDir, COPIER_FILE)
+	err := os.WriteFile(copierFile, []byte("# test copier file"), 0644)
+	require.NoError(t, err)
+
+	build := container.Build{
+		Folder: tempDir,
+	}
+
+	assert.True(t, Matches(build))
+}
+
+func TestMatches_WithoutCopierFile(t *testing.T) {
+	// Create a temporary directory without copier.yml
+	tempDir := t.TempDir()
+
+	build := container.Build{
+		Folder: tempDir,
+	}
+
+	assert.False(t, Matches(build))
+}
+
+func TestMatches_EmptyFolder(t *testing.T) {
+	build := container.Build{
+		Folder: "", // Empty folder defaults to "./"
+	}
+
+	// This will check "./" + COPIER_FILE in the current working directory
+	// Since we're in test context, it likely won't find one
+	result := Matches(build)
+	// We can't assert a specific value here since it depends on the current working directory
+	// But we can verify the function doesn't crash
+	assert.IsType(t, false, result) // Just check it returns a boolean
+}
+
+func TestExtractTemplateData(t *testing.T) {
+	tests := []struct {
+		custom   map[string][]string
+		expected []string
+		name     string
+	}{
+		{
+			name: "all parameters provided",
+			custom: map[string][]string{
+				"data": {
+					"service_name=test-service",
+					"team=test-team",
+					"domain=test-domain",
+					"namespace=test-namespace",
+					"business_domain_name=test-business-domain",
+					"environments=shared,staging,production",
+					"service_account=test-service@example.com",
+					"pre_commit_entry=bash -c 'cd build/test-service && test'",
+				},
+			},
+			expected: []string{
+				"service_name=test-service",
+				"team=test-team",
+				"domain=test-domain",
+				"namespace=test-namespace",
+				"business_domain_name=test-business-domain",
+				"environments=shared,staging,production",
+				"service_account=test-service@example.com",
+				"pre_commit_entry=bash -c 'cd build/test-service && test'",
+			},
+		},
+		{
+			name:     "no parameters provided",
+			custom:   map[string][]string{},
+			expected: []string{},
+		},
+		{
+			name: "partial parameters provided",
+			custom: map[string][]string{
+				"data": {
+					"service_name=test-service",
+					"team=test-team",
+				},
+			},
+			expected: []string{
+				"service_name=test-service",
+				"team=test-team",
+			},
+		},
+		{
+			name: "empty values",
+			custom: map[string][]string{
+				"data": {
+					"service_name=",
+					"team=",
+				},
+			},
+			expected: []string{
+				"service_name=",
+				"team=",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			build := container.Build{
+				Custom: tt.custom,
+			}
+
+			result := extractTemplateData(build)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractTemplatePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		custom   map[string][]string
+		expected string
+	}{
+		{
+			name: "template path provided",
+			custom: map[string][]string{
+				"template_path": {"/path/to/template"},
+			},
+			expected: "/path/to/template",
+		},
+		{
+			name:     "no template path provided",
+			custom:   map[string][]string{},
+			expected: "",
+		},
+		{
+			name: "empty template path",
+			custom: map[string][]string{
+				"template_path": {},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			build := container.Build{
+				Custom: tt.custom,
+			}
+
+			result := extractTemplatePath(build)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildCopierCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateData []string
+		templatePath string
+		targetFolder string
+		expected     []string
+	}{
+		{
+			name: "full command with all parameters",
+			templateData: []string{
+				"service_name=test-service",
+				"team=test-team",
+				"domain=test-domain",
+			},
+			templatePath: "/path/to/template",
+			targetFolder: "build/test-service",
+			expected: []string{
+				"copier", "copy",
+				"--data", "service_name=test-service",
+				"--data", "team=test-team",
+				"--data", "domain=test-domain",
+				"--defaults", "/path/to/template",
+				"build/test-service",
+			},
+		},
+		{
+			name: "minimal command without template path",
+			templateData: []string{
+				"service_name=test-service",
+			},
+			templatePath: "",
+			targetFolder: ".",
+			expected: []string{
+				"copier", "copy",
+				"--data", "service_name=test-service",
+				".",
+			},
+		},
+		{
+			name:         "no data parameters",
+			templateData: []string{},
+			templatePath: "/path/to/template",
+			targetFolder: "target",
+			expected: []string{
+				"copier", "copy",
+				"--defaults", "/path/to/template",
+				"target",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			copierContainer := &CopierContainer{
+				TemplateData: tt.templateData,
+				TemplatePath: tt.templatePath,
+				TargetFolder: tt.targetFolder,
+			}
+
+			result := copierContainer.buildCopierCommand()
+
+			// Check that all expected elements are present
+			for _, expected := range tt.expected {
+				assert.Contains(t, result, expected, "Expected element %s not found in result %v", expected, result)
+			}
+
+			// Check the basic structure
+			assert.Equal(t, "copier", result[0])
+			assert.Equal(t, "copy", result[1])
+			assert.Equal(t, tt.targetFolder, result[len(result)-1])
+		})
+	}
+}
+
+func TestNew_Constructor(t *testing.T) {
+	build := container.Build{
+		Folder: "./test",
+		Custom: map[string][]string{
+			"data": {
+				"service_name=test-service",
+			},
+			"template_path": {"/path/to/template"},
+			"output_path":   {"./test"},
+		},
+	}
+
+	copierContainer := new(build)
+
+	assert.NotNil(t, copierContainer.Container)
+	assert.Equal(t, &build, copierContainer.Build)
+	assert.Equal(t, "./test", copierContainer.SourceFolder)
+	assert.Equal(t, "./test", copierContainer.TargetFolder)
+	assert.Equal(t, "service_name=test-service", copierContainer.TemplateData[0])
+	assert.Equal(t, "/path/to/template", copierContainer.TemplatePath)
+}
+
+func TestBuildCopierCommand_ParameterOrder(t *testing.T) {
+	copierContainer := &CopierContainer{
+		TemplateData: []string{
+			"service_name=test-service",
+			"team=test-team",
+		},
+		TemplatePath: "/template",
+		TargetFolder: "target",
+	}
+
+	result := copierContainer.buildCopierCommand()
+
+	// Verify the command structure
+	assert.Equal(t, "copier", result[0])
+	assert.Equal(t, "copy", result[1])
+
+	// Find data parameters
+	dataParams := []string{}
+	for i := 2; i < len(result); i++ {
+		if result[i] == "--data" && i+1 < len(result) {
+			dataParams = append(dataParams, result[i+1])
+		}
+	}
+
+	// Verify we have the expected data parameters
+	assert.Len(t, dataParams, 2)
+	assert.Contains(t, dataParams, "service_name=test-service")
+	assert.Contains(t, dataParams, "team=test-team")
+
+	// Verify defaults parameter
+	defaultsIndex := -1
+	for i, arg := range result {
+		if arg == "--defaults" {
+			defaultsIndex = i
+			break
+		}
+	}
+	assert.NotEqual(t, -1, defaultsIndex)
+	assert.Equal(t, "/template", result[defaultsIndex+1])
+
+	// Verify target is last
+	assert.Equal(t, "target", result[len(result)-1])
+}
+
+func TestBuildCopierCommand_CommandString(t *testing.T) {
+	copierContainer := &CopierContainer{
+		TemplateData: []string{
+			"service_name=some-service",
+			"team=some-team",
+		},
+		TemplatePath: "/path/to/template",
+		TargetFolder: "build/some-service",
+	}
+
+	result := copierContainer.buildCopierCommand()
+	cmdString := strings.Join(result, " ")
+
+	// Verify the command contains expected patterns
+	assert.Contains(t, cmdString, "copier copy")
+	assert.Contains(t, cmdString, "--data service_name=some-service")
+	assert.Contains(t, cmdString, "--data team=some-team")
+	assert.Contains(t, cmdString, "--defaults /path/to/template")
+	assert.Contains(t, cmdString, "build/some-service")
+}

--- a/pkg/copier/copier_test.go
+++ b/pkg/copier/copier_test.go
@@ -69,8 +69,8 @@ func TestMatches_EmptyFolder(t *testing.T) {
 func TestExtractTemplateData(t *testing.T) {
 	tests := []struct {
 		custom   map[string][]string
-		expected []string
 		name     string
+		expected []string
 	}{
 		{
 			name: "all parameters provided",

--- a/pkg/cri/docker/docker.go
+++ b/pkg/cri/docker/docker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -93,6 +94,16 @@ func (d *DockerManager) CreateContainer(ctx context.Context, opts *types.Contain
 	hostConfig := &container.HostConfig{
 		Mounts:       ToMounts(opts.Volumes),
 		PortBindings: portMap,
+	}
+
+	//There is no easy secret management for docker containers similar to podman
+	if len(opts.Secrets) > 0 {
+		if len(config.Env) == 0 {
+			config.Env = []string{}
+		}
+		for k, v := range opts.Secrets {
+			config.Env = append(config.Env, fmt.Sprintf("%s=%s", k, v))
+		}
 	}
 
 	netConfig := &network.NetworkingConfig{}

--- a/pkg/cri/podman/podman.go
+++ b/pkg/cri/podman/podman.go
@@ -152,7 +152,10 @@ func (p *PodmanManager) CreateContainer(ctx context.Context, opts *types.Contain
 		s.EnvSecrets = map[string]string{}
 		for k, v := range opts.Secrets {
 			s.EnvSecrets[k] = k
-			p.ensureSecret(ctx, k, v)
+			err := p.ensureSecret(ctx, k, v)
+			if err != nil {
+				return "", fmt.Errorf("failed to ensure secret %s: %w", k, err)
+			}
 		}
 	}
 	s.Name = opts.Name

--- a/pkg/cri/podman/podman.go
+++ b/pkg/cri/podman/podman.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containers/podman/v5/pkg/bindings/containers"
 	"github.com/containers/podman/v5/pkg/bindings/images"
 	"github.com/containers/podman/v5/pkg/bindings/manifests"
+	"github.com/containers/podman/v5/pkg/bindings/secrets"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/docker/docker/api/types/container"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -103,6 +104,15 @@ func (d *PodmanManager) Name() string {
 	return "podman"
 }
 
+func (p *PodmanManager) ensureSecret(ctx context.Context, name, value string) error {
+	// Create/replace from an in-memory reader
+	r := strings.NewReader(value)
+	_, err := secrets.Create(p.conn, r, new(secrets.CreateOptions).
+		WithName(name).
+		WithReplace(true)) // or WithIgnore(true) on newer releases
+	return err
+}
+
 // CreateContainer creates a container
 func (p *PodmanManager) CreateContainer(ctx context.Context, opts *types.ContainerConfig, authBase64 string) (string, error) {
 	s := specgen.NewSpecGenerator(opts.Image, false)
@@ -137,6 +147,13 @@ func (p *PodmanManager) CreateContainer(ctx context.Context, opts *types.Contain
 			envs[k] = v
 		}
 		s.Env = envs
+	}
+	if len(opts.Secrets) > 0 {
+		s.EnvSecrets = map[string]string{}
+		for k, v := range opts.Secrets {
+			s.EnvSecrets[k] = k
+			p.ensureSecret(ctx, k, v)
+		}
 	}
 	s.Name = opts.Name
 	s.User = opts.User
@@ -576,7 +593,7 @@ func (p *PodmanManager) InspectContainer(ctx context.Context, id string) (*types
 		Entrypoint:   meta.Config.Entrypoint,
 		Env:          meta.Config.Env,
 		ExposedPorts: ports,
-		Image:        meta.Image,
+		Image:        meta.ImageName,
 		Name:         meta.Name,
 		Platform:     platform,
 		Tty:          meta.Config.Tty,

--- a/pkg/cri/types/container.go
+++ b/pkg/cri/types/container.go
@@ -33,23 +33,22 @@ type ReadinessProbe struct {
 }
 
 type ContainerConfig struct {
-	ExposedPorts []Binding
-	Volumes      []Volume // List of volumes (mounts) used for the container
-	Platform     *Platform
 	Readiness    *ReadinessProbe `json:"-"`
-	Image        string          // Name of the image as it was passed by the operator (e.g., could be symbolic)
+	Secrets      map[string]string
+	Platform     *Platform
+	WorkingDir   string
+	Image        string
 	Name         string
 	Script       string
-	User         string // User that will run the command(s) inside the container, also supports user:group
-	WorkingDir   string // Current directory (PWD) in which the command will be launched
+	User         string
+	ExposedPorts []Binding
 	Cmd          []string
 	Entrypoint   []string
-	Env          []string // List of environment variable to set in the container
+	Env          []string
+	Volumes      []Volume
 	Memory       int64
 	CPU          uint64
-	Tty          bool // Attach standard streams to a tty, including stdin if it is not closed
-
-	Secrets map[string]string
+	Tty          bool
 }
 
 // type ContainerConfig struct {

--- a/pkg/cri/types/container.go
+++ b/pkg/cri/types/container.go
@@ -48,6 +48,8 @@ type ContainerConfig struct {
 	Memory       int64
 	CPU          uint64
 	Tty          bool // Attach standard streams to a tty, including stdin if it is not closed
+
+	Secrets map[string]string
 }
 
 // type ContainerConfig struct {

--- a/pkg/cri/utils/socket.go
+++ b/pkg/cri/utils/socket.go
@@ -44,6 +44,9 @@ func PodmanSocket() (*ContainerSocket, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get podman socket info: %w", err)
 	}
+	if strings.HasPrefix(string(cmd), "unix://") {
+		cmd = cmd[7:]
+	}
 	podmanSocket := strings.TrimSpace(string(cmd))
 	return &ContainerSocket{
 		RuntimeType: Podman,

--- a/pkg/gcloud/oidc.go
+++ b/pkg/gcloud/oidc.go
@@ -121,6 +121,7 @@ func (c *GCloudContainer) Auth() error {
 	}
 
 	opts.Env = []string{}
+	opts.Secrets = c.Secret
 
 	googleADC := u.GetEnvWithDefault("GOOGLE_APPLICATION_CREDENTIALS", func() string {
 		//TODO support multiple os (its only for macos)
@@ -191,7 +192,7 @@ func Image(build *container.Build) string {
 }
 
 func (c *GCloudContainer) Run() error {
-	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") == "" ||
+	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") == "" &&
 		c.GetBuild().CustomString("gcloud_oidc") == "" {
 		slog.Info("No ACTIONS_ID_TOKEN_REQUEST_URL found and Custom property gcloud_oidc not set, skipping gcloud_oidc container", "ACTIONS_ID_TOKEN_REQUEST_URL", os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"), "gcloud_oidc", c.GetBuild().CustomString("gcloud_oidc"))
 		return nil

--- a/pkg/gcloud/src/main.go
+++ b/pkg/gcloud/src/main.go
@@ -44,14 +44,22 @@ func setValue(key, value string) error {
 
 	fmt.Printf("Store in mem %s", url)
 
-	resp, err := http.Post(url, "text/plain", bytes.NewBuffer([]byte(value)))
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewBuffer([]byte(value)))
+	req.Header.Set("Authorization", "Bearer "+os.Getenv("CONTAINIFYCI_AUTH"))
 	if err != nil {
-		slog.Error("error post request", "error", err)
+		fmt.Println("error create request", "error", err)
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Println("error post request", "error", err)
 		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		fmt.Println("failed to set key-value pair", "error", err, resp.Status)
 		return fmt.Errorf("failed to set key-value pair: %s", resp.Status)
 	}
 

--- a/pkg/golang/alpine/golang.go
+++ b/pkg/golang/alpine/golang.go
@@ -164,7 +164,7 @@ func (c *GoContainer) Lint() error {
 		os.Exit(1)
 	}
 
-	script := NewGolangCiLint().LintScript(c.Tags)
+	script := NewGolangCiLint().LintScript(c.Tags, c.Folder)
 	err = c.CopyContentTo(script, "/tmp/script.sh")
 	if err != nil {
 		slog.Error("Failed to start container", "error", err)

--- a/pkg/golang/alpine/golangcilint.go
+++ b/pkg/golang/alpine/golangcilint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/containifyci/engine-ci/pkg/filesystem"
@@ -65,10 +66,10 @@ func (cg *customGCL) Defaults() {
 	}
 }
 
-func (c GolangCiLint) Command(tags string) string {
+func (c GolangCiLint) Command(tags string, folder string) string {
 	cmd := fmt.Sprintf("golangci-lint -v run %s --timeout=5m", tags)
-	if c.reader.FileExists(".custom-gcl.yml") {
-		cnt, err := c.reader.ReadFile(".custom-gcl.yml")
+	if c.reader.FileExists(filepath.Join(folder, ".custom-gcl.yml")) {
+		cnt, err := c.reader.ReadFile(filepath.Join(folder, ".custom-gcl.yml"))
 		if err != nil {
 			slog.Error("Failed to read .custom-gcl.yml file", "error", err)
 			os.Exit(1)
@@ -88,13 +89,13 @@ func (c GolangCiLint) Command(tags string) string {
 	return cmd
 }
 
-func (c GolangCiLint) LintScript(tags []string) string {
+func (c GolangCiLint) LintScript(tags []string, folder string) string {
 	_tags := ""
 	if len(tags) > 0 {
 		_tags = "--build-tags " + strings.Join(tags, ",")
 	}
 
-	cmd := c.Command(_tags)
+	cmd := c.Command(_tags, folder)
 	//TODO: add suport for custom-gcl in the future
 	script := fmt.Sprintf(`#!/bin/sh
 set -x

--- a/pkg/golang/alpine/golangcilint_test.go
+++ b/pkg/golang/alpine/golangcilint_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCopyLintScript(t *testing.T) {
 	gcl := NewGolangCiLint()
-	script := gcl.LintScript([]string{"build_tag"})
+	script := gcl.LintScript([]string{"build_tag"}, ".")
 
 	assert.Equal(t, `#!/bin/sh
 set -x
@@ -30,7 +30,7 @@ func TestCopyLintScriptGCL(t *testing.T) {
 			},
 		},
 	}
-	script := gcl.LintScript([]string{"build_tag"})
+	script := gcl.LintScript([]string{"build_tag"}, ".")
 
 	assert.Equal(t, `#!/bin/sh
 set -x

--- a/pkg/kv/api.go
+++ b/pkg/kv/api.go
@@ -14,8 +14,8 @@ import (
 
 type Server struct {
 	Listener net.Listener
-	Port     int
 	Secret   string
+	Port     int
 }
 
 // In-memory key-value store

--- a/pkg/kv/api.go
+++ b/pkg/kv/api.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"crypto/rand"
 	"crypto/subtle"
 	"fmt"
 	"io"
@@ -91,7 +92,11 @@ func (kv *KeyValueStore) Set(w http.ResponseWriter, r *http.Request) {
 func getRandomPort() (*Server, error) {
 	//TODO define maximal retries
 	for {
-		port := rand.Intn(65535-1024) + 1024 // Random port between 1024 and 65535
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(65535-1024)))
+		if err != nil {
+			panic(fmt.Sprintf("crypto/rand failed: %v", err))
+		}
+		port := int(num.Int64()) + 1024
 		l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 		if err == nil {
 			return &Server{

--- a/pkg/kv/api.go
+++ b/pkg/kv/api.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/rand"
+	"math/big"
 	"net"
 	"net/http"
 	"strings"
@@ -154,7 +154,11 @@ func randomString(n int) string {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			panic(fmt.Sprintf("crypto/rand failed: %v", err))
+		}
+		b[i] = letters[num.Int64()]
 	}
 	return string(b)
 }

--- a/pkg/kv/api_test.go
+++ b/pkg/kv/api_test.go
@@ -110,6 +110,7 @@ func TestStartHttpServer(t *testing.T) {
 
 	// Test the /health endpoint
 	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", srv.Secret))
 	w := httptest.NewRecorder()
 	http.DefaultServeMux.ServeHTTP(w, req)
 
@@ -127,6 +128,7 @@ func TestStartHttpServer(t *testing.T) {
 	url = fmt.Sprintf("http://localhost:%d/mem/foo", srv.Port)
 
 	req = httptest.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", srv.Secret))
 	req.SetPathValue("key", "foo")
 	w = httptest.NewRecorder()
 	http.DefaultServeMux.ServeHTTP(w, req)

--- a/pkg/network/localhost.go
+++ b/pkg/network/localhost.go
@@ -15,8 +15,8 @@ var RuntimeOS = runtime.GOOS
 type Address struct {
 	Host         string
 	InternalHost string
-	Port         int
 	Secret       string
+	Port         int
 }
 
 func (a *Address) NewAddress(arg *container.Build) {

--- a/pkg/network/localhost.go
+++ b/pkg/network/localhost.go
@@ -16,6 +16,7 @@ type Address struct {
 	Host         string
 	InternalHost string
 	Port         int
+	Secret       string
 }
 
 func (a *Address) NewAddress(arg *container.Build) {

--- a/pkg/python/Dockerfile.python
+++ b/pkg/python/Dockerfile.python
@@ -3,13 +3,13 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 RUN apt-get update && \
-    apt-get install -y gcc python3-dev libpq-dev && \
+    apt-get install -y gcc python3-dev libpq-dev curl && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # RUN pip3 --no-cache install uv
 # RUN pip3 install --force-reinstall --platform musllinux_1_1_x86_64 --upgrade --only-binary=:all: --target ./ uv
-{{ .INSTALL_UV }}
+{{ .INSTALL_BUILD_TOOLS }}
 
 WORKDIR /app

--- a/pkg/python/builder.go
+++ b/pkg/python/builder.go
@@ -1,0 +1,143 @@
+package python
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Tool string
+type Commands [][]string
+
+func (c Commands) String() string {
+	var cmds []string
+	for _, cmd := range c {
+		cmds = append(cmds, strings.Join(cmd, " "))
+	}
+	return strings.Join(cmds, "\n")
+}
+
+const (
+	ToolUV     Tool = "uv"
+	ToolPoetry Tool = "poetry"
+	ToolPip    Tool = "pip"
+)
+
+type Builder struct {
+	Folder string
+	Tool   Tool
+
+	files Files
+}
+
+type Files struct {
+	pyproject    string
+	requirements string
+	poetryLock   string
+	uvLock       string
+}
+
+func NewBuilder(folder string) *Builder {
+	builder := &Builder{
+		Folder: folder,
+	}
+
+	return builder
+}
+
+func (b *Builder) Analyze() (Tool, error) {
+	pyproject := filepath.Join(b.Folder, "pyproject.toml")
+	requirements := filepath.Join(b.Folder, "requirements.txt")
+	poetryLock := filepath.Join(b.Folder, "poetry.lock")
+	uvLock := filepath.Join(b.Folder, "uv.lock")
+
+	pyprojectContent := readFile(pyproject)
+
+	files := Files{
+		pyproject:    pyproject,
+		requirements: requirements,
+		poetryLock:   poetryLock,
+		uvLock:       uvLock,
+	}
+	b.files = files
+
+	// Heuristics (prefer explicit signals):
+	// 1) Poetry if pyproject has [tool.poetry] or poetry.lock
+	// 2) uv if pyproject suggests uv (tool.uv, dependency-groups) or uv.lock present
+	// 3) pip if requirements.txt or a generic pyproject without poetry/uv hints
+	// 4) fallback to what's installed: uv > poetry > pip
+	var chosen Tool
+	switch {
+	case containsSection(pyprojectContent, "tool.uv") || fileExists(uvLock) || strings.Contains(pyprojectContent, "[dependency-groups]"):
+		chosen = ToolUV
+	case containsSection(pyprojectContent, "tool.poetry") || fileExists(poetryLock):
+		chosen = ToolPoetry
+	case fileExists(requirements) || (fileExists(pyproject) && !containsSection(pyprojectContent, "tool.poetry")):
+		// leaning pip for plain pyproject or requirements.txt
+		chosen = ToolPip
+	default:
+		chosen = ToolUV
+	}
+	b.Tool = chosen
+	return chosen, nil
+}
+
+func (b *Builder) Build() (Commands, error) {
+
+	fmt.Printf("🔎 Detected build tool: %s\n", b.Tool)
+
+	// Build command plan
+	var plan Commands
+	switch b.Tool {
+	case ToolUV:
+		// Install deps
+		plan = append(plan, []string{"uv", "sync"})
+		// Build distribution if pyproject exists (most modern projects)
+		if fileExists(b.files.pyproject) {
+			plan = append(plan, []string{"uv", "build"})
+		}
+	case ToolPoetry:
+		plan = append(plan, []string{"poetry", "install", "--no-interaction"})
+		plan = append(plan, []string{"poetry", "build"})
+	case ToolPip:
+		python := "python3"
+		// Install deps
+		if fileExists(b.files.requirements) {
+			plan = append(plan, []string{python, "-m", "pip", "install", "-r", "requirements.txt"})
+		} else if fileExists(b.files.pyproject) {
+			// PEP 517 build front-end; install build tool if missing
+			plan = append(plan,
+				[]string{python, "-m", "pip", "install", "--upgrade", "pip", "build"},
+				[]string{python, "-m", "build", "--wheel", "--sdist"},
+			)
+		} else {
+			return nil, errors.New("no recognizable Python project files found (need pyproject.toml or requirements.txt)")
+		}
+	default:
+		return nil, fmt.Errorf("unknown tool %q", b.Tool)
+	}
+
+	return plan, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func readFile(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func containsSection(toml string, dotted string) bool {
+	// crude but effective: match either [tool.poetry] or [tool.poetry.something]
+	needle := "[" + dotted + "]"
+	needlePrefix := "[" + dotted + "."
+	return strings.Contains(toml, needle) || strings.Contains(toml, needlePrefix)
+}

--- a/pkg/python/buildscript.go
+++ b/pkg/python/buildscript.go
@@ -35,9 +35,9 @@ func (pi PrivateIndex) Environ() string {
 
 type BuildScript struct {
 	Folder       string
-	Verbose      bool
-	Commands     Commands
 	PrivateIndex PrivateIndex
+	Commands     Commands
+	Verbose      bool
 }
 
 func NewBuildScript(folder string, verbose bool, privateIndex PrivateIndex, commands Commands) *BuildScript {

--- a/pkg/python/buildscript.go
+++ b/pkg/python/buildscript.go
@@ -1,14 +1,51 @@
 package python
 
-type Image string
+import (
+	"fmt"
+	"strings"
 
-type BuildScript struct {
-	Verbose bool
+	"github.com/containifyci/engine-ci/pkg/container"
+)
+
+type Image string
+type PrivateIndex string
+
+func NewPrivateIndex(custom container.Custom) PrivateIndex {
+	pi := custom.String("private_index")
+	return PrivateIndex(pi)
 }
 
-func NewBuildScript(verbose bool) *BuildScript {
+func (pi PrivateIndex) String() string {
+	return strings.ReplaceAll(strings.ToUpper(string(pi)), "-", "_")
+}
+
+func (pi PrivateIndex) Username() string {
+	if pi == "" {
+		return ""
+	}
+	return fmt.Sprintf("UV_INDEX_%s_USERNAME=oauth2accesstoken", pi.String())
+}
+
+func (pi PrivateIndex) Environ() string {
+	if pi == "" {
+		return ""
+	}
+	return fmt.Sprintf("export UV_INDEX_%s_PASSWORD=\"$(curl -fsS -H \"Authorization: Bearer ${CONTAINIFYCI_AUTH}\" \"${CONTAINIFYCI_HOST}/mem/accesstoken\")\"", pi.String())
+}
+
+type BuildScript struct {
+	Folder       string
+	Verbose      bool
+	Commands     Commands
+	PrivateIndex PrivateIndex
+}
+
+func NewBuildScript(folder string, verbose bool, privateIndex PrivateIndex, commands Commands) *BuildScript {
 	return &BuildScript{
-		Verbose: verbose,
+		Folder:       folder,
+		Verbose:      verbose,
+		Commands:     commands,
+		PrivateIndex: privateIndex,
 	}
 }
 
@@ -20,23 +57,23 @@ func Script(bs *BuildScript) string {
 }
 
 func simpleScript(bs *BuildScript) string {
-	return `#!/bin/sh
+	cmd := bs.Commands.String()
+	return fmt.Sprintf(`#!/bin/sh
+set -e
+%s
 set -xe
-#pip3 --disable-pip-version-check install -r requirements.txt --no-compile --no-warn-script-location
-uv pip install -r requirements.txt  --system
-#pip install  -r requirements.txt
-# coverage run -m pytest && coverage xml
-#chmod 0755 -R /root/.cache/pip
-`
+cd %s
+%s
+`, bs.PrivateIndex.Environ(), bs.Folder, cmd)
 }
 
 func verboseScript(bs *BuildScript) string {
-	return `#!/bin/sh
+	cmd := bs.Commands.String()
+	return fmt.Sprintf(`#!/bin/sh
+set -e
+%s
 set -xe
-#pip3 --disable-pip-version-check install -r requirements.txt --no-compile --no-warn-script-location
-uv pip install -r requirements.txt --system
-#pip install -r requirements.txt
-# coverage run -m pytest && coverage xml
-#chmod 0755 -R /root/.cache/pip
-`
+cd %s
+%s
+`, bs.PrivateIndex.Environ(), bs.Folder, cmd)
 }

--- a/pkg/python/buildscript_test.go
+++ b/pkg/python/buildscript_test.go
@@ -1,0 +1,28 @@
+package python
+
+import (
+	"testing"
+
+	"github.com/containifyci/engine-ci/pkg/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrivateIndexEmpty(t *testing.T) {
+	custom := container.Custom{}
+	pi := NewPrivateIndex(custom)
+
+	assert.Equal(t, "", pi.String())
+	assert.Equal(t, "", pi.Username())
+	assert.Equal(t, "", pi.Environ())
+}
+
+func TestPrivateIndex(t *testing.T) {
+	custom := container.Custom{
+		"private_index": []string{"data-utils"},
+	}
+	pi := NewPrivateIndex(custom)
+
+	assert.Equal(t, "DATA_UTILS", pi.String())
+	assert.Equal(t, "UV_INDEX_DATA_UTILS_USERNAME=oauth2accesstoken", pi.Username())
+	assert.Equal(t, `export UV_INDEX_DATA_UTILS_PASSWORD="$(curl -fsS -H "Authorization: Bearer ${CONTAINIFYCI_AUTH}" "${CONTAINIFYCI_HOST}/mem/accesstoken")"`, pi.Environ())
+}

--- a/pkg/python/python.go
+++ b/pkg/python/python.go
@@ -217,7 +217,11 @@ func (c *PythonContainer) BuildScript() string {
 	// Create a temporary script in-memory
 
 	builder := NewBuilder(c.Folder)
-	builder.Analyze()
+	_, err := builder.Analyze()
+	if err != nil {
+		slog.Error("Failed to analyze python project", "error", err)
+		os.Exit(1)
+	}
 	cmds, err := builder.Build()
 	if err != nil {
 		slog.Error("Failed to build python commands", "error", err)


### PR DESCRIPTION
Enhance container build functionality by adding support for managing secrets within Docker and Podman containers.

This update includes modifications to various build scripts and commands, enabling better handling of sensitive information during container reation and execution.

- Add secret handling capability in Docker and Podman
- Update in memory HTTP server to utilize authorization through secrets
- Modify Python container build process to support new secret management
- Create a standardized method to configure secrets for multiple builds