### PR TITLE
fix(python): add dummy release command for python

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containifyci/engine-ci/pkg/build"
 	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/containifyci/engine-ci/pkg/copier"
+	"github.com/containifyci/engine-ci/pkg/dummy"
 	"github.com/containifyci/engine-ci/pkg/gcloud"
 	"github.com/containifyci/engine-ci/pkg/github"
 	"github.com/containifyci/engine-ci/pkg/golang"
@@ -173,6 +174,8 @@ func Pre(arg *container.Build, bs *build.BuildSteps) (*container.Build, *build.B
 		addStep(build.Publish, goreleaser.New()) // Goreleaser
 		addStep(build.Publish, github.New())     // GitHub (async)
 
+		addStep(build.Publish, dummy.New()) // Goreleaser
+
 		bs.Init()
 	}
 
@@ -260,6 +263,9 @@ func (c *Command) Run(addr network.Address, target string, arg *container.Build)
 		})
 		c.AddTarget("push", func() error {
 			return bs.Run(arg, "python-prod")
+		})
+		c.AddTarget("release", func() error {
+			return bs.Run(arg, "dummy")
 		})
 	}
 	c.AddTarget("all", func() error {

--- a/cmd/engine.go
+++ b/cmd/engine.go
@@ -88,7 +88,7 @@ func Engine(cmd *cobra.Command, _ []string) error {
 				c := NewCommand(*b, _buildSteps)
 				err := c.Run(addr, RootArgs.Target, b)
 				if err != nil {
-					slog.Error("Executing command", "command", c)
+					slog.Error("Executing command", "error", err, "command", c)
 					os.Exit(1)
 				}
 			}(b)

--- a/pkg/dummy/dummy.go
+++ b/pkg/dummy/dummy.go
@@ -1,0 +1,24 @@
+package dummy
+
+import (
+	"log/slog"
+
+	"github.com/containifyci/engine-ci/pkg/build"
+	"github.com/containifyci/engine-ci/pkg/container"
+)
+
+func Matches(build container.Build) bool {
+	return true
+}
+
+func New() build.BuildStepv2 {
+	return build.Stepper{
+		RunFn: func(build container.Build) error {
+			slog.Info("Dummy build step executed", "build", build)
+			return nil
+		},
+		MatchedFn: Matches,
+		Name_:     "dummy",
+		Async_:    false,
+	}
+}

--- a/pkg/dummy/dummy_test.go
+++ b/pkg/dummy/dummy_test.go
@@ -1,0 +1,20 @@
+package dummy
+
+import (
+	"testing"
+
+	"github.com/containifyci/engine-ci/pkg/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDummyBuildStep(t *testing.T) {
+	step := New()
+
+	assert.Equal(t, "dummy", step.Name())
+	assert.True(t, step.Matches(container.Build{}))
+	assert.False(t, step.IsAsync())
+	err := step.RunWithBuild(container.Build{
+		Image: "dummy-image",
+	})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This dummy command is used for the Github Release workflow. It just prints a log message that's all. Still it lets finish the Github release workflow which creates release and a tag. But for example don't upload any artifacts as it would for a golang repository with a gorelease file.

Later the dummy release command can be replaced with a proper python release command that handles artifact uploads similar to goreleaser maybe.