### PR TITLE
Potential fix for code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/pkg/cri/podman/podman.go
+++ b/pkg/cri/podman/podman.go
@@ -195,10 +195,18 @@ func (p *PodmanManager) CreateContainer(ctx context.Context, opts *types.Contain
 			slog.Error("Failed to convert host port to int", "error", err)
 			return "", err
 		}
+		if hport < 0 || hport > 65535 {
+			slog.Error("Host port out of range", "port", hport)
+			return "", fmt.Errorf("host port %d out of range (0-65535)", hport)
+		}
 		cport, err := strconv.Atoi(p.Container.Port)
 		if err != nil {
 			slog.Error("Failed to convert container port to int", "error", err)
 			return "", err
+		}
+		if cport < 0 || cport > 65535 {
+			slog.Error("Container port out of range", "port", cport)
+			return "", fmt.Errorf("container port %d out of range (0-65535)", cport)
 		}
 
 		s.PortMappings = append(s.PortMappings, nettypes.PortMapping{


### PR DESCRIPTION
Potential fix for [https://github.com/containifyci/engine-ci/security/code-scanning/4](https://github.com/containifyci/engine-ci/security/code-scanning/4)

The best way to fix this problem is to add explicit bounds checks after parsing each port number to ensure that their values lie within the valid range for `uint16`: 0 to 65535, inclusive. If the number is out of bounds, handle the error gracefully, either by returning an error or assigning a default (refusing the configuration). In file `pkg/cri/podman/podman.go`, in the `CreateContainer` function, after parsing both `hport` and `cport`, add checks of the form `if hport < 0 || hport > 65535 { ... }`. Use the same check for `cport`. If out of bounds, log a suitable error and return. No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
