### PR TITLE
fix(code scanning): alert no. 6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/pkg/cri/utils/tar.go
+++ b/pkg/cri/utils/tar.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // extractTar extracts a tar archive from the provided io.Reader to the target directory.
@@ -27,7 +28,7 @@ func ExtractTar(r io.Reader, targetDir string) error {
 		// Determine the target file path
 		// Resolve the target path and ensure it is within the target directory
 		targetPath := filepath.Join(targetDir, header.Name)
-		if !strings.HasPrefix(filepath.Clean(targetPath), filepath.Clean(targetDir)+string(os.PathSeparator)) {
+		if !strings.HasPrefix(filepath.Clean(targetPath), filepath.Join(filepath.Clean(targetDir), string(os.PathSeparator))) {
 			return fmt.Errorf("invalid file path in tar archive: %s", header.Name)
 		}
 


### PR DESCRIPTION
Potential fix for [https://github.com/containifyci/engine-ci/security/code-scanning/6](https://github.com/containifyci/engine-ci/security/code-scanning/6)

To fix the issue, we need to validate the `header.Name` field to ensure it does not contain directory traversal elements (`..`) or absolute paths. This can be achieved by resolving the `header.Name` to an absolute path and ensuring it is within the intended `targetDir`. If the resolved path is outside `targetDir`, the entry should be skipped or rejected. This approach ensures that only safe paths are used for file system operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
