### PR TITLE
chore(client): update Go version and add tests

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -1,11 +1,12 @@
 module github.com/containifyci/engine-ci/client
 
-go 1.24.2
+go 1.25.5
 
 require (
 	github.com/containifyci/engine-ci/protos2 v0.22.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
+	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/client/pkg/build/ai_test.go
+++ b/client/pkg/build/ai_test.go
@@ -1,0 +1,132 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/containifyci/engine-ci/protos2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:testparallel // use t.Setenv which is not compatible with t.Parallel
+func TestNewAIBuild(t *testing.T) {
+	t.Run("creates AI build with name", func(t *testing.T) {
+		build := NewAIBuild("test-ai")
+		require.NotNil(t, build)
+		assert.Equal(t, "test-ai", build.Application)
+		assert.Equal(t, protos2.BuildType_AI, build.BuildType)
+	})
+
+	t.Run("uses COMMIT_SHA for image tag", func(t *testing.T) {
+		t.Setenv("COMMIT_SHA", "def456")
+
+		build := NewAIBuild("test-ai")
+		assert.Equal(t, "def456", build.ImageTag)
+	})
+
+	t.Run("uses local when COMMIT_SHA not set", func(t *testing.T) {
+		build := NewAIBuild("test-ai")
+		assert.Equal(t, "local", build.ImageTag)
+	})
+
+	t.Run("uses correct environment", func(t *testing.T) {
+		t.Setenv("ENV", "local")
+
+		build := NewAIBuild("test-ai")
+		assert.Equal(t, protos2.EnvType_local, build.Environment)
+	})
+}
+
+func TestNewClaudeBuild(t *testing.T) {
+	t.Parallel()
+	t.Run("creates Claude build with prompt", func(t *testing.T) {
+		t.Parallel()
+		prompt := "Fix the bug in main.go"
+		build := NewClaudeBuild(prompt)
+		require.NotNil(t, build)
+		assert.Equal(t, "claude-agent", build.Application)
+		assert.Equal(t, protos2.BuildType_AI, build.BuildType)
+	})
+
+	t.Run("includes prompt in properties", func(t *testing.T) {
+		t.Parallel()
+		prompt := "Write tests for package"
+		build := NewClaudeBuild(prompt)
+		require.NotNil(t, build.Properties)
+		assert.Contains(t, build.Properties, "ai_prompt")
+		promptList := build.Properties["ai_prompt"]
+		require.NotNil(t, promptList)
+		assert.Len(t, promptList.Values, 1)
+		assert.Equal(t, prompt, promptList.Values[0].GetStringValue())
+	})
+
+	t.Run("handles empty prompt", func(t *testing.T) {
+		t.Parallel()
+		build := NewClaudeBuild("")
+		require.NotNil(t, build)
+		assert.Contains(t, build.Properties, "ai_prompt")
+	})
+
+	t.Run("handles multi-line prompt", func(t *testing.T) {
+		t.Parallel()
+		prompt := "Line 1\nLine 2\nLine 3"
+		build := NewClaudeBuild(prompt)
+		promptList := build.Properties["ai_prompt"]
+		assert.Equal(t, prompt, promptList.Values[0].GetStringValue())
+	})
+}
+
+func TestNewAgentBuild(t *testing.T) {
+	t.Parallel()
+	t.Run("creates agent build with prompt", func(t *testing.T) {
+		t.Parallel()
+		prompt := "Implement feature X"
+		build := NewAgentBuild(prompt, 5)
+		require.NotNil(t, build)
+		assert.Equal(t, "claude-agent", build.Application)
+		assert.Equal(t, protos2.BuildType_AI, build.BuildType)
+	})
+
+	t.Run("sets agent_mode to true", func(t *testing.T) {
+		t.Parallel()
+		build := NewAgentBuild("test prompt", 3)
+		require.NotNil(t, build.Properties)
+		assert.Contains(t, build.Properties, "agent_mode")
+		agentMode := build.Properties["agent_mode"]
+		require.NotNil(t, agentMode)
+		assert.Equal(t, "true", agentMode.Values[0].GetStringValue())
+	})
+
+	t.Run("sets max_iterations when positive", func(t *testing.T) {
+		t.Parallel()
+		build := NewAgentBuild("test prompt", 10)
+		require.NotNil(t, build.Properties)
+		assert.Contains(t, build.Properties, "max_iterations")
+		maxIter := build.Properties["max_iterations"]
+		require.NotNil(t, maxIter)
+		assert.Equal(t, "10", maxIter.Values[0].GetStringValue())
+	})
+
+	t.Run("does not set max_iterations when zero", func(t *testing.T) {
+		t.Parallel()
+		build := NewAgentBuild("test prompt", 0)
+		require.NotNil(t, build.Properties)
+		assert.NotContains(t, build.Properties, "max_iterations")
+	})
+
+	t.Run("does not set max_iterations when negative", func(t *testing.T) {
+		t.Parallel()
+		build := NewAgentBuild("test prompt", -1)
+		require.NotNil(t, build.Properties)
+		assert.NotContains(t, build.Properties, "max_iterations")
+	})
+
+	t.Run("includes prompt in properties", func(t *testing.T) {
+		t.Parallel()
+		prompt := "Complex multi-step task"
+		build := NewAgentBuild(prompt, 5)
+		assert.Contains(t, build.Properties, "ai_prompt")
+		promptList := build.Properties["ai_prompt"]
+		assert.Equal(t, prompt, promptList.Values[0].GetStringValue())
+	})
+}

--- a/client/pkg/build/build_test.go
+++ b/client/pkg/build/build_test.go
@@ -1,0 +1,137 @@
+package build
+
+import (
+	"os"
+	"testing"
+
+	"github.com/containifyci/engine-ci/protos2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewList(t *testing.T) {
+	t.Parallel()
+	t.Run("creates list with single value", func(t *testing.T) {
+		t.Parallel()
+		list := NewList("value1")
+		require.NotNil(t, list)
+		assert.Len(t, list.Values, 1)
+		assert.Equal(t, "value1", list.Values[0].GetStringValue())
+	})
+
+	t.Run("creates list with multiple values", func(t *testing.T) {
+		t.Parallel()
+		list := NewList("value1", "value2", "value3")
+		require.NotNil(t, list)
+		assert.Len(t, list.Values, 3)
+		assert.Equal(t, "value1", list.Values[0].GetStringValue())
+		assert.Equal(t, "value2", list.Values[1].GetStringValue())
+		assert.Equal(t, "value3", list.Values[2].GetStringValue())
+	})
+
+	t.Run("creates empty list", func(t *testing.T) {
+		t.Parallel()
+		list := NewList()
+		require.NotNil(t, list)
+		assert.Len(t, list.Values, 0)
+	})
+}
+
+//nolint:testparallel // use t.Setenv which is not compatible with t.Parallel
+func TestGetEnv(t *testing.T) {
+	t.Run("returns local for ENV=local", func(t *testing.T) {
+		t.Setenv("ENV", "local")
+
+		env := getEnv()
+		assert.Equal(t, protos2.EnvType_local, env)
+	})
+
+	t.Run("returns build for other ENV values", func(t *testing.T) {
+		t.Setenv("ENV", "production")
+
+		env := getEnv()
+		assert.Equal(t, protos2.EnvType_build, env)
+	})
+
+	t.Run("returns build for empty ENV", func(t *testing.T) {
+		env := getEnv()
+		assert.Equal(t, protos2.EnvType_build, env)
+	})
+}
+
+//nolint:testparallel // use t.Setenv which is not compatible with t.Parallel
+func TestNewGoServiceBuild(t *testing.T) {
+	t.Run("creates go service build", func(t *testing.T) {
+		build := NewGoServiceBuild("test-app")
+		require.NotNil(t, build)
+		assert.Equal(t, "test-app", build.Application)
+		assert.Equal(t, protos2.BuildType_GoLang, build.BuildType)
+		assert.Equal(t, "test-app", build.Image)
+	})
+
+	t.Run("uses COMMIT_SHA for image tag", func(t *testing.T) {
+		t.Setenv("COMMIT_SHA", "abc123")
+
+		build := NewGoServiceBuild("test-app")
+		assert.Equal(t, "abc123", build.ImageTag)
+	})
+
+	t.Run("uses local for missing COMMIT_SHA", func(t *testing.T) {
+		// Ensure COMMIT_SHA is not set
+		err := os.Unsetenv("COMMIT_SHA")
+		require.NoError(t, err)
+
+		build := NewGoServiceBuild("test-app")
+		assert.Equal(t, "local", build.ImageTag)
+	})
+}
+
+func TestNewGoLibraryBuild(t *testing.T) {
+	t.Parallel()
+	t.Run("creates go library build", func(t *testing.T) {
+		t.Parallel()
+		build := NewGoLibraryBuild("test-lib")
+		require.NotNil(t, build)
+		assert.Equal(t, "test-lib", build.Application)
+		assert.Equal(t, protos2.BuildType_GoLang, build.BuildType)
+		assert.Empty(t, build.Image, "library should have empty image")
+	})
+}
+
+func TestNewMavenServiceBuild(t *testing.T) {
+	t.Parallel()
+	build := NewMavenServiceBuild("test-maven")
+	require.NotNil(t, build)
+	assert.Equal(t, "test-maven", build.Application)
+	assert.Equal(t, protos2.BuildType_Maven, build.BuildType)
+	assert.Equal(t, "test-maven", build.Image)
+	assert.Equal(t, "target/quarkus-app", build.Folder)
+}
+
+func TestNewMavenLibraryBuild(t *testing.T) {
+	t.Parallel()
+	build := NewMavenLibraryBuild("test-maven-lib")
+	require.NotNil(t, build)
+	assert.Equal(t, "test-maven-lib", build.Application)
+	assert.Equal(t, protos2.BuildType_Maven, build.BuildType)
+	assert.Empty(t, build.Image, "library should have empty image")
+	assert.Equal(t, "target/quarkus-app", build.Folder)
+}
+
+func TestNewPythonServiceBuild(t *testing.T) {
+	t.Parallel()
+	build := NewPythonServiceBuild("test-python")
+	require.NotNil(t, build)
+	assert.Equal(t, "test-python", build.Application)
+	assert.Equal(t, protos2.BuildType_Python, build.BuildType)
+	assert.Equal(t, "test-python", build.Image)
+}
+
+func TestNewPythonLibraryBuild(t *testing.T) {
+	t.Parallel()
+	build := NewPythonLibraryBuild("test-python-lib")
+	require.NotNil(t, build)
+	assert.Equal(t, "test-python-lib", build.Application)
+	assert.Equal(t, protos2.BuildType_Python, build.BuildType)
+	assert.Empty(t, build.Image, "library should have empty image")
+}

--- a/client/pkg/random/uuid_test.go
+++ b/client/pkg/random/uuid_test.go
@@ -1,0 +1,73 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewUUID(t *testing.T) {
+	t.Parallel()
+	t.Run("generates valid UUID", func(t *testing.T) {
+		t.Parallel()
+		uuid, err := NewUUID()
+		require.NoError(t, err)
+		assert.NotEmpty(t, uuid)
+
+		// Check format: 8-4-4-4-12 hexadecimal characters
+		assert.Len(t, uuid, 36) // 32 hex chars + 4 hyphens
+		assert.Contains(t, uuid, "-")
+
+		// Check that it's properly formatted
+		parts := []int{8, 13, 18, 23} // positions of hyphens
+		for _, pos := range parts {
+			assert.Equal(t, "-", string(uuid[pos]))
+		}
+	})
+
+	t.Run("generates unique UUIDs", func(t *testing.T) {
+		t.Parallel()
+		uuid1, err := NewUUID()
+		require.NoError(t, err)
+
+		uuid2, err := NewUUID()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, uuid1, uuid2)
+	})
+
+	t.Run("version 4 UUID", func(t *testing.T) {
+		t.Parallel()
+		uuid, err := NewUUID()
+		require.NoError(t, err)
+
+		// Version 4 UUID should have '4' as the first character of the 3rd group
+		assert.Equal(t, "4", string(uuid[14]))
+	})
+
+	t.Run("variant RFC 4122", func(t *testing.T) {
+		t.Parallel()
+		uuid, err := NewUUID()
+		require.NoError(t, err)
+
+		// Variant bits should be 10xx in binary (8, 9, a, or b in hex)
+		variantChar := uuid[19]
+		assert.Contains(t, "89ab", string(variantChar))
+	})
+
+	t.Run("generates multiple unique UUIDs", func(t *testing.T) {
+		t.Parallel()
+		uuids := make(map[string]bool)
+		count := 100
+
+		for i := 0; i < count; i++ {
+			uuid, err := NewUUID()
+			require.NoError(t, err)
+			assert.False(t, uuids[uuid], "UUID collision detected")
+			uuids[uuid] = true
+		}
+
+		assert.Len(t, uuids, count)
+	})
+}


### PR DESCRIPTION
Upgrade Go version to 1.25.5 and add comprehensive unit tests for build-related functionalities.

- Add tests for AI build creation
- Add tests for new build types: Go, Maven, Python
- Introduce tests for UUID generation and uniqueness
- Update Go version in go.mod