### PR TITLE
chore(workflow): update token for creating release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,4 @@ jobs:
           generateReleaseNotes: true
           makeLatest: true
           tag: ${{ steps.semver.outputs.next }}
-          token: ${{ secrets.CONTAINIFYCI_RELEASE_TOKEN }}
+          token: ${{ github.token }}


### PR DESCRIPTION
Replace the `CONTAINIFYCI_RELEASE_TOKEN` with the `github.token` in the release workflow configuration.