### PR TITLE
refactor(build): the buildsteps return BuildResult

### DIFF
--- a/cmd/engine.go
+++ b/cmd/engine.go
@@ -119,22 +119,22 @@ func executeBuild(b *container.Build, leader *LeaderElection, idStore *utils.IDS
 	}
 
 	c := NewCommand(*b, buildSteps)
-	ids, loop, err := c.Run(addr, RootArgs.Target, b)
-	slog.Info("Build completed", "app", b.App, "ids", ids)
+	result := c.Run(addr, RootArgs.Target, b)
+	slog.Info("Build completed", "app", b.App, "ids", result.IDs, "loop", result.Loop)
 
-	if err != nil {
-		slog.Error("Executing command", "error", err, "command", c)
+	if result.Error != nil {
+		slog.Error("Executing command", "error", result.Error, "command", c)
 		if !aiConfig.Enabled {
 			os.Exit(1)
 		}
 	}
 
-	if loop == container.BuildStop {
+	if result.Loop == container.BuildStop {
 		slog.Info("Build requested to stop further builds", "app", b.App)
 		os.Exit(0)
 	}
 
-	idStore.Add(ids...)
+	idStore.Add(result.IDs...)
 }
 
 // executeBuildGroup executes all builds in a group in parallel using goroutines.

--- a/internal/service/main.go
+++ b/internal/service/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/client"
 
 	"github.com/containifyci/engine-ci/cmd"
+	"github.com/containifyci/engine-ci/pkg/build"
 	"github.com/containifyci/engine-ci/pkg/container"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -66,10 +67,10 @@ func createContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c := cmd.NewCommand(buildArgs, nil)
-	c.AddTarget("all", func() ([]string, container.BuildLoop, error) {
+	c.AddTarget("all", func() build.BuildResult {
 		fmt.Println("Running build")
 		// cmd.RunBuild(nil, nil)
-		return nil, container.BuildContinue, nil
+		return build.BuildResult{Loop: container.BuildContinue}
 	})
 	// addr := Start()
 


### PR DESCRIPTION
Update the command structure and target functions to utilize a unified BuildResult type.

This change make it possible to add more metadata to the build results in the future without breaking multiple function signatures.

- Introduce BuildResult struct to encapsulate build results.
- Update usage in the command execution flows.
- Change target function signatures to return BuildResult.