### PR TITLE
fix(folder): support source folder

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -51,7 +51,7 @@ func main() {
 	pr2.Image = ""
 
 	client := build.NewGoServiceBuild("engine-ci-client")
-	client.File = "client/client.go"
+	client.File = "client.go"
 	client.Folder = "client"
 	client.Image = ""
 

--- a/pkg/golang/alpine/golang.go
+++ b/pkg/golang/alpine/golang.go
@@ -78,7 +78,7 @@ func new(build container.Build) *GoContainer {
 		// FIX: linux-arm64 go build is needed when building contains on MacOS M1/M2
 		Platforms: platforms,
 		// Platforms: []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")},
-		File:   u.SrcFile(build.File),
+		File:   u.NewSrcFile(build.Folder, build.File),
 		Folder: build.Folder,
 		Tags:   build.Custom["tags"],
 	}

--- a/pkg/golang/alpine/golangcilint.go
+++ b/pkg/golang/alpine/golangcilint.go
@@ -68,6 +68,10 @@ func (cg *customGCL) Defaults() {
 
 func (c GolangCiLint) Command(tags string, folder string) string {
 	cmd := fmt.Sprintf("golangci-lint -v run %s --timeout=5m", tags)
+	if !c.reader.FileExists(filepath.Join(folder, ".golangci.yml")) {
+		cmd = fmt.Sprintf("golangci-lint -v run %s --timeout=5m", tags)
+	}
+
 	if c.reader.FileExists(filepath.Join(folder, ".custom-gcl.yml")) {
 		cnt, err := c.reader.ReadFile(filepath.Join(folder, ".custom-gcl.yml"))
 		if err != nil {

--- a/pkg/golang/debian/golang.go
+++ b/pkg/golang/debian/golang.go
@@ -81,7 +81,7 @@ func new(build container.Build) *GoContainer {
 		// FIX: linux-arm64 go build is needed when building contains on MacOS M1/M2
 		// Platforms: []*types.PlatformSpec{types.ParsePlatform("darwin/arm64"), types.ParsePlatform("linux/arm64")},
 		Platforms: platforms,
-		File:      u.SrcFile(build.File),
+		File:      u.NewSrcFile(build.Folder, build.File),
 		Folder:    build.Folder,
 		Tags:      build.Custom["tags"],
 	}

--- a/pkg/golang/debiancgo/golang.go
+++ b/pkg/golang/debiancgo/golang.go
@@ -74,7 +74,7 @@ func new(build container.Build) *GoContainer {
 		Image:     build.Image,
 		ImageTag:  build.ImageTag,
 		Platforms: platforms,
-		File:      u.SrcFile(build.File),
+		File:      u.NewSrcFile(build.Folder, build.File),
 		Folder:    build.Folder,
 		Tags:      build.Custom["tags"],
 	}

--- a/pkg/utils/environment_test.go
+++ b/pkg/utils/environment_test.go
@@ -152,3 +152,51 @@ func TestGetMemValue(t *testing.T) {
 	val = GetValue("mem:key2", "local")
 	assert.Equal(t, "", val)
 }
+
+func TestRunCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "successful command",
+			cmd:     "echo hello",
+			want:    "hello",
+			wantErr: false,
+		},
+		{
+			name:    "command with newline trimmed",
+			cmd:     "printf 'test\\n'",
+			want:    "test",
+			wantErr: false,
+		},
+		{
+			name:    "failing command",
+			cmd:     "exit 1",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "non-existent command",
+			cmd:     "nonexistentcommand12345",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := RunCommand(tt.cmd)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.want, *result)
+			}
+		})
+	}
+}

--- a/pkg/utils/idstore_test.go
+++ b/pkg/utils/idstore_test.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIDStore_Add(t *testing.T) {
+	tests := []struct {
+		name string
+		ids  [][]string
+		want []string
+	}{
+		{
+			name: "add single ID",
+			ids:  [][]string{{"id1"}},
+			want: []string{"id1"},
+		},
+		{
+			name: "add multiple IDs at once",
+			ids:  [][]string{{"id1", "id2", "id3"}},
+			want: []string{"id1", "id2", "id3"},
+		},
+		{
+			name: "add IDs in multiple calls",
+			ids:  [][]string{{"id1"}, {"id2"}, {"id3"}},
+			want: []string{"id1", "id2", "id3"},
+		},
+		{
+			name: "add empty",
+			ids:  [][]string{{}},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &IDStore{}
+			for _, ids := range tt.ids {
+				store.Add(ids...)
+			}
+			assert.Equal(t, tt.want, store.Get())
+		})
+	}
+}
+
+func TestIDStore_Get(t *testing.T) {
+	tests := []struct {
+		name     string
+		initialIDs []string
+		want     []string
+	}{
+		{
+			name:     "empty store",
+			initialIDs: nil,
+			want:     nil,
+		},
+		{
+			name:     "store with IDs",
+			initialIDs: []string{"id1", "id2"},
+			want:     []string{"id1", "id2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &IDStore{}
+			if tt.initialIDs != nil {
+				store.Add(tt.initialIDs...)
+			}
+			assert.Equal(t, tt.want, store.Get())
+		})
+	}
+}
+
+func TestIDStore_Concurrent(t *testing.T) {
+	store := &IDStore{}
+	var wg sync.WaitGroup
+
+	// Concurrent writes
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			store.Add(id)
+		}(string(rune('a' + i)))
+	}
+
+	wg.Wait()
+
+	// Verify all IDs were added
+	ids := store.Get()
+	assert.Len(t, ids, 10)
+}

--- a/pkg/utils/srcfile.go
+++ b/pkg/utils/srcfile.go
@@ -1,6 +1,12 @@
 package utils
 
+import "path/filepath"
+
 type SrcFile string
+
+func NewSrcFile(folder, file string) SrcFile {
+	return SrcFile(filepath.Join(folder, file))
+}
 
 func (s SrcFile) IsEmpty() bool {
 	return s == ""

--- a/pkg/utils/srcfile_test.go
+++ b/pkg/utils/srcfile_test.go
@@ -41,41 +41,6 @@ func TestSrcFile_IsEmpty(t *testing.T) {
 	}
 }
 
-func TestSrcFile_IsNotEmpty(t *testing.T) {
-	tests := []struct {
-		name string
-		s    SrcFile
-		want bool
-	}{
-		{
-			name: "empty string",
-			s:    SrcFile(""),
-			want: false,
-		},
-		{
-			name: "non-empty string",
-			s:    SrcFile("file.go"),
-			want: true,
-		},
-		{
-			name: "whitespace only",
-			s:    SrcFile(" "),
-			want: true,
-		},
-		{
-			name: "path string",
-			s:    SrcFile("/src/main.go"),
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.s.IsNotEmpty())
-		})
-	}
-}
-
 func TestSrcFile_Container(t *testing.T) {
 	tests := []struct {
 		name string
@@ -89,32 +54,37 @@ func TestSrcFile_Container(t *testing.T) {
 		},
 		{
 			name: "special case /src/main.go",
-			s:    SrcFile("/src/main.go"),
+			s:    NewSrcFile("/src", "main.go"),
 			want: "/src/main.go",
 		},
 		{
 			name: "regular file",
-			s:    SrcFile("file.go"),
+			s:    NewSrcFile("", "file.go"),
 			want: "/src/file.go",
 		},
 		{
+			name: "regular file",
+			s:    NewSrcFile("go-app", "file.go"),
+			want: "/src/go-app/file.go",
+		},
+		{
 			name: "file with path",
-			s:    SrcFile("pkg/utils/helper.go"),
+			s:    NewSrcFile("pkg/utils", "helper.go"),
 			want: "/src/pkg/utils/helper.go",
 		},
 		{
 			name: "absolute path not /src/main.go",
-			s:    SrcFile("/home/user/file.go"),
+			s:    NewSrcFile("/home/user/", "file.go"),
 			want: "/src//home/user/file.go",
 		},
 		{
 			name: "relative path with dots",
-			s:    SrcFile("../file.go"),
+			s:    NewSrcFile("..", "file.go"),
 			want: "/src/../file.go",
 		},
 		{
 			name: "file with spaces",
-			s:    SrcFile("my file.go"),
+			s:    NewSrcFile("", "my file.go"),
 			want: "/src/my file.go",
 		},
 	}


### PR DESCRIPTION
Add support to define folder and source files for mono repos to build multiple go projects in the containifyci.go file.