### PR TITLE
chore(zig): update Zig version to 0.16.0

### DIFF
--- a/.containifyci/containifyci.go
+++ b/.containifyci/containifyci.go
@@ -115,7 +115,7 @@ func main() {
 
 func DockerFile() *protos2.ContainerFile {
 	return &protos2.ContainerFile{
-		Name: "golang-1.26.1-alpine-custom",
+		Name: "golang-1.26.2-alpine-custom",
 		Content: `FROM golang:1.26.1-alpine
 
 RUN apk --no-cache add git openssh-client && \

--- a/pkg/zig/Dockerfile.zig
+++ b/pkg/zig/Dockerfile.zig
@@ -1,12 +1,13 @@
 FROM --platform=$TARGETPLATFORM alpine:3.23
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG ZIG_VERSION=0.15.2
+ARG ZIG_VERSION=0.16.0
 
 RUN apk add --no-cache curl xz && \
-    curl -L https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz \
+    ZIG_ARCH=$(uname -m | sed 's/arm64/aarch64/' | sed 's/amd64/x86_64/') && \
+    curl -L https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz \
     | tar -xJ -C /usr/local && \
-    ln -s /usr/local/zig-x86_64-linux-${ZIG_VERSION}/zig /usr/local/bin/zig && \
+    ln -s /usr/local/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}/zig /usr/local/bin/zig && \
     apk del curl xz && \
     rm -rf /var/cache/apk/*
 

--- a/pkg/zig/docker_metadata_gen.go
+++ b/pkg/zig/docker_metadata_gen.go
@@ -8,19 +8,20 @@ const (
 	ImageVersion = "3.23"
 
 	// DockerfileChecksum is the checksum of the Dockerfile content
-	DockerfileChecksum = "37a9225ae146b47244ee518f7c273bc7f2e2c2577eb26f66c650eb1117997042"
+	DockerfileChecksum = "37498818f15880a8599ce58008eef3a3d75d33f25d0300d42c95c5a7efca9539"
 )
 
 // DockerfileContent contains the embedded Dockerfile content
 var DockerfileContent = `FROM --platform=$TARGETPLATFORM alpine:3.23
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG ZIG_VERSION=0.15.2
+ARG ZIG_VERSION=0.16.0
 
-RUN apk add --no-cache curl xz && \
-    curl -L https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz \
+RUN apk add --no-cache curl xz openssl-dev && \
+    ZIG_ARCH=$(uname -m | sed 's/arm64/aarch64/' | sed 's/amd64/x86_64/') && \
+    curl -L https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz \
     | tar -xJ -C /usr/local && \
-    ln -s /usr/local/zig-x86_64-linux-${ZIG_VERSION}/zig /usr/local/bin/zig && \
+    ln -s /usr/local/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}/zig /usr/local/bin/zig && \
     apk del curl xz && \
     rm -rf /var/cache/apk/*
 

--- a/pkg/zig/docker_metadata_gen.go
+++ b/pkg/zig/docker_metadata_gen.go
@@ -8,7 +8,7 @@ const (
 	ImageVersion = "3.23"
 
 	// DockerfileChecksum is the checksum of the Dockerfile content
-	DockerfileChecksum = "37498818f15880a8599ce58008eef3a3d75d33f25d0300d42c95c5a7efca9539"
+	DockerfileChecksum = "82a0e911deb344a641209b6a5d360a0e65a64f8de8bb30ae2e6baa3efed132d2"
 )
 
 // DockerfileContent contains the embedded Dockerfile content
@@ -17,7 +17,7 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG ZIG_VERSION=0.16.0
 
-RUN apk add --no-cache curl xz openssl-dev && \
+RUN apk add --no-cache curl xz && \
     ZIG_ARCH=$(uname -m | sed 's/arm64/aarch64/' | sed 's/amd64/x86_64/') && \
     curl -L https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz \
     | tar -xJ -C /usr/local && \


### PR DESCRIPTION
Upgrade Zig from version 0.15.2 to 0.16.0 in Dockerfiles. Adjust the download URL and symbolic link to support the new architecture handling.

- Update Zig version to 0.16.0
- Modify downloading process for Zig based on architecture