### PR TITLE
chore: jaxxstorm/action-install-gh-release@v3.0.0

### DIFF
--- a/.github/workflows/engine-ci-workflow.yml
+++ b/.github/workflows/engine-ci-workflow.yml
@@ -159,7 +159,7 @@ jobs:
             ${{ runner.os }}-cache-
 
       - name: Install Engine CI
-        uses: jaxxstorm/action-install-gh-release@v1
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
         if: ${{ inputs.install_binary }}
         with:
           repo: containifyci/engine-ci


### PR DESCRIPTION
Update to jaxxstorm/action-install-gh-release@v3.0.0 to fix deprecated usage of Node.js 20 actions.